### PR TITLE
feat: integrate vocabulary practice with real backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ Tome is a web app to help memorise information you have read. It is built around
 - [App Specifications](./docs/capabilities/tome.md) — core concepts, design principles
 - [Knowledge Base](./docs/kb.md) — topics, sections, and how knowledge is structured
 - [Memory & Challenges](./docs/capabilities/memory-challenges.md) — challenges, trials, scoring, and accuracy
-- [Language Learning](./docs/capabilities/language-learning.md) — vocabulary practice and inversions
+- [Language Learning](./docs/capabilities/language/language-learning.md) — vocabulary practice and inversions
 - [Practice Points](./docs/practice-points.md) — how practice points are earned
 - [Badges](./docs/badges.md) — badge system
+
+### Specs
+
+#### Language Learning
+- [Language Learning Summary](./docs/specs/language-learning/language-learning-summary.md) — overview of language learning features
+- [Home Page](./docs/specs/language-learning/home-page.md) — language learning home page behaviour
+- [Vocabulary Management](./docs/specs/language-learning/vocabulary-management.md) — adding and managing vocabulary
+- [Vocabulary Practice](./docs/specs/language-learning/vocabulary-practice.md) — vocabulary practice session flow and API integration
+- [Inversions](./docs/specs/language-learning/inversions.md) — inversion practice

--- a/api/IVocabularyPracticeAPI.ts
+++ b/api/IVocabularyPracticeAPI.ts
@@ -1,7 +1,7 @@
 import { VocabPracticeSession, SessionSummary } from '@/model/VocabularyPractice';
 
 export interface IVocabularyPracticeAPI {
-  startSession(): Promise<VocabPracticeSession>;
+  startSession(language: string): Promise<VocabPracticeSession>;
   getActiveSession(): Promise<VocabPracticeSession | null>;
   submitAnswer(sessionId: string, wordId: string, isCorrect: boolean): Promise<void>;
   completeSession(sessionId: string): Promise<SessionSummary>;

--- a/api/MockVocabularyPracticeAPI.ts
+++ b/api/MockVocabularyPracticeAPI.ts
@@ -1,7 +1,7 @@
 import { IVocabularyPracticeAPI } from './IVocabularyPracticeAPI';
 import { VocabPracticeSession, VocabPracticeWord, SessionSummary } from '@/model/VocabularyPractice';
 
-const STORAGE_KEY = 'vocab-practice-session';
+const ACTIVE_SESSION_KEY = 'vocab-active-session';
 
 const HARDCODED_WORDS: Omit<VocabPracticeWord, 'failedAttempts'>[] = [
   { id: 'w1',  english: 'dog',      translation: 'hund'     },
@@ -24,88 +24,146 @@ function generateUUID(): string {
   });
 }
 
+interface QueueState {
+  sessionId: string;
+  pendingQueue: string[];
+  masteredIds: string[];
+  deferredIds: string[];
+  firstAttemptCorrectIds: string[];
+  wordFailedAttempts: Record<string, number>;
+}
+
+interface SessionMetadata {
+  sessionId: string;
+  words: VocabPracticeWord[];
+  totalWords: number;
+}
+
+function queueStateKey(sessionId: string): string {
+  return `vocab-queue-${sessionId}`;
+}
+
 export class MockVocabularyPracticeAPI implements IVocabularyPracticeAPI {
 
-  async startSession(): Promise<VocabPracticeSession> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async startSession(_language: string): Promise<VocabPracticeSession> {
     const words: VocabPracticeWord[] = HARDCODED_WORDS.map((w) => ({ ...w, failedAttempts: 0 }));
-    const session: VocabPracticeSession = {
-      sessionId: generateUUID(),
-      words,
+    const sessionId = generateUUID();
+
+    const metadata: SessionMetadata = { sessionId, words, totalWords: words.length };
+    localStorage.setItem(ACTIVE_SESSION_KEY, JSON.stringify(metadata));
+
+    const initialQueue: QueueState = {
+      sessionId,
       pendingQueue: words.map((w) => w.id),
+      masteredIds: [],
+      deferredIds: [],
+      firstAttemptCorrectIds: [],
+      wordFailedAttempts: Object.fromEntries(words.map((w) => [w.id, 0])),
+    };
+    localStorage.setItem(queueStateKey(sessionId), JSON.stringify(initialQueue));
+
+    return {
+      sessionId,
+      words,
+      pendingQueue: initialQueue.pendingQueue,
       masteredIds: [],
       deferredIds: [],
       firstAttemptCorrectIds: [],
       totalWords: words.length,
     };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
-    return session;
   }
 
   async getActiveSession(): Promise<VocabPracticeSession | null> {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
+    const rawMeta = localStorage.getItem(ACTIVE_SESSION_KEY);
+    if (!rawMeta) return null;
+
+    let metadata: SessionMetadata;
     try {
-      const session: VocabPracticeSession = JSON.parse(raw);
-      return session;
+      metadata = JSON.parse(rawMeta);
     } catch {
       return null;
     }
-  }
 
-  async submitAnswer(sessionId: string, wordId: string, isCorrect: boolean): Promise<void> {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return;
-    const session: VocabPracticeSession = JSON.parse(raw);
-    if (session.sessionId !== sessionId) return;
+    const { sessionId, words, totalWords } = metadata;
 
-    if (isCorrect) {
-      // Check first-attempt status BEFORE removing from deferredIds
-      const isFirstAttempt = !session.deferredIds.includes(wordId);
-      // Move word from the front of the queue to mastered
-      session.pendingQueue = session.pendingQueue.filter((id) => id !== wordId);
-      session.masteredIds = [...session.masteredIds, wordId];
-      // Remove from deferred now that the word is mastered
-      session.deferredIds = session.deferredIds.filter((id) => id !== wordId);
-      // Count as first-attempt-correct only if it was never deferred
-      if (isFirstAttempt) {
-        session.firstAttemptCorrectIds = [...session.firstAttemptCorrectIds, wordId];
+    // Restore or initialise queue state
+    const rawQueue = localStorage.getItem(queueStateKey(sessionId));
+    let queue: QueueState | null = null;
+    if (rawQueue) {
+      try {
+        queue = JSON.parse(rawQueue);
+      } catch {
+        queue = null;
       }
-    } else {
-      // Move the word to the end of the queue and track as deferred
-      session.pendingQueue = [...session.pendingQueue.filter((id) => id !== wordId), wordId];
-      if (!session.deferredIds.includes(wordId)) {
-        session.deferredIds = [...session.deferredIds, wordId];
-      }
-      // Increment failedAttempts
-      const word = session.words.find((w) => w.id === wordId);
-      if (word) word.failedAttempts += 1;
     }
 
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    if (!queue) {
+      queue = {
+        sessionId,
+        pendingQueue: words.map((w) => w.id),
+        masteredIds: [],
+        deferredIds: [],
+        firstAttemptCorrectIds: [],
+        wordFailedAttempts: Object.fromEntries(words.map((w) => [w.id, 0])),
+      };
+    }
+
+    const restoredWords = words.map((w) => ({
+      ...w,
+      failedAttempts: queue!.wordFailedAttempts[w.id] ?? 0,
+    }));
+
+    return {
+      sessionId,
+      words: restoredWords,
+      pendingQueue: queue.pendingQueue,
+      masteredIds: queue.masteredIds,
+      deferredIds: queue.deferredIds,
+      firstAttemptCorrectIds: queue.firstAttemptCorrectIds,
+      totalWords,
+    };
+  }
+
+  // Queue state is managed by the page component — this is a no-op.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async submitAnswer(_sessionId: string, _wordId: string, _isCorrect: boolean): Promise<void> {
+    // No-op: the page persists queue state to localStorage after each answer.
   }
 
   async completeSession(sessionId: string): Promise<SessionSummary> {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) throw new Error('No active session found');
-    const session: VocabPracticeSession = JSON.parse(raw);
-    if (session.sessionId !== sessionId) throw new Error('Session ID mismatch');
+    const rawQueue = localStorage.getItem(queueStateKey(sessionId));
+    if (!rawQueue) throw new Error('No queue state found for session');
 
-    const firstAttemptCorrect = session.firstAttemptCorrectIds.length;
-    const accuracy = Math.round((firstAttemptCorrect / session.totalWords) * 100);
+    let queue: QueueState;
+    try {
+      queue = JSON.parse(rawQueue);
+    } catch {
+      throw new Error('Failed to parse queue state');
+    }
+
+    const rawMeta = localStorage.getItem(ACTIVE_SESSION_KEY);
+    if (!rawMeta) throw new Error('No active session found');
+    const metadata: SessionMetadata = JSON.parse(rawMeta);
+
+    const firstAttemptCorrect = queue.firstAttemptCorrectIds.length;
+    const accuracy = Math.round((firstAttemptCorrect / metadata.totalWords) * 100);
 
     const summary: SessionSummary = {
-      totalWords: session.totalWords,
+      totalWords: metadata.totalWords,
       firstAttemptCorrect,
       accuracy,
-      wordResults: session.words.map((w) => ({
+      wordResults: metadata.words.map((w) => ({
         wordId: w.id,
         english: w.english,
         translation: w.translation,
-        failedAttempts: w.failedAttempts,
+        failedAttempts: queue.wordFailedAttempts[w.id] ?? 0,
       })),
     };
 
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(ACTIVE_SESSION_KEY);
+    localStorage.removeItem(queueStateKey(sessionId));
+
     return summary;
   }
 }

--- a/api/TomeVocabularyPracticeAPI.ts
+++ b/api/TomeVocabularyPracticeAPI.ts
@@ -1,21 +1,164 @@
 import { IVocabularyPracticeAPI } from './IVocabularyPracticeAPI';
-import { VocabPracticeSession, SessionSummary } from '@/model/VocabularyPractice';
+import { VocabPracticeSession, VocabPracticeWord, SessionSummary } from '@/model/VocabularyPractice';
+import { TotoAPI } from './TotoAPI';
+
+const api = new TotoAPI();
+
+function queueStateKey(sessionId: string): string {
+  return `vocab-queue-${sessionId}`;
+}
+
+interface QueueState {
+  sessionId: string;
+  pendingQueue: string[];
+  masteredIds: string[];
+  deferredIds: string[];
+  firstAttemptCorrectIds: string[];
+  wordFailedAttempts: Record<string, number>;
+}
+
+interface BackendWord {
+  wordId: string;
+  english: string;
+  translation: string;
+}
+
+interface BackendSessionResponse {
+  sessionId: string;
+  payload: {
+    words: BackendWord[];
+    totalWords: number;
+  };
+}
+
+function mapBackendWords(backendWords: BackendWord[]): VocabPracticeWord[] {
+  return backendWords.map((w) => ({
+    id: w.wordId,
+    english: w.english,
+    translation: w.translation,
+    failedAttempts: 0,
+  }));
+}
+
+function buildSessionFromBackend(
+  data: BackendSessionResponse,
+  queue: QueueState
+): VocabPracticeSession {
+  const words = mapBackendWords(data.payload.words).map((w) => ({
+    ...w,
+    failedAttempts: queue.wordFailedAttempts[w.id] ?? 0,
+  }));
+  return {
+    sessionId: data.sessionId,
+    words,
+    pendingQueue: queue.pendingQueue,
+    masteredIds: queue.masteredIds,
+    deferredIds: queue.deferredIds,
+    firstAttemptCorrectIds: queue.firstAttemptCorrectIds,
+    totalWords: data.payload.totalWords,
+  };
+}
+
+function initialQueueState(sessionId: string, words: VocabPracticeWord[]): QueueState {
+  return {
+    sessionId,
+    pendingQueue: words.map((w) => w.id),
+    masteredIds: [],
+    deferredIds: [],
+    firstAttemptCorrectIds: [],
+    wordFailedAttempts: Object.fromEntries(words.map((w) => [w.id, 0])),
+  };
+}
 
 export class TomeVocabularyPracticeAPI implements IVocabularyPracticeAPI {
 
-  async startSession(): Promise<VocabPracticeSession> {
-    throw new Error('Not implemented — backend API contract pending');
+  async startSession(language: string): Promise<VocabPracticeSession> {
+    const response = await api.fetch(
+      'tome-ms-language',
+      `/tomelang/languages/${language}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ practiceType: 'vocabulary' }),
+      }
+    );
+
+    if (response.status === 409) {
+      throw new Error('You already have an active session. Please complete or resume it before starting a new one.');
+    }
+    if (!response.ok) {
+      throw new Error(`Failed to start session (${response.status})`);
+    }
+
+    const data: BackendSessionResponse = await response.json();
+    const words = mapBackendWords(data.payload.words);
+    const queue = initialQueueState(data.sessionId, words);
+
+    localStorage.setItem(queueStateKey(data.sessionId), JSON.stringify(queue));
+
+    return buildSessionFromBackend(data, queue);
   }
 
   async getActiveSession(): Promise<VocabPracticeSession | null> {
-    throw new Error('Not implemented — backend API contract pending');
+    const response = await api.fetch('tome-ms-language', '/tomelang/sessions/active');
+
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(`Failed to fetch active session (${response.status})`);
+    }
+
+    const data: BackendSessionResponse = await response.json();
+    const words = mapBackendWords(data.payload.words);
+
+    // Restore queue state from localStorage, falling back to fresh initialisation
+    const rawQueue = localStorage.getItem(queueStateKey(data.sessionId));
+    let queue: QueueState | null = null;
+    if (rawQueue) {
+      try {
+        queue = JSON.parse(rawQueue);
+      } catch {
+        queue = null;
+      }
+    }
+    if (!queue) {
+      queue = initialQueueState(data.sessionId, words);
+      localStorage.setItem(queueStateKey(data.sessionId), JSON.stringify(queue));
+    }
+
+    return buildSessionFromBackend(data, queue);
   }
 
-  async submitAnswer(_sessionId: string, _wordId: string, _isCorrect: boolean): Promise<void> {
-    throw new Error('Not implemented — backend API contract pending');
+  async submitAnswer(sessionId: string, wordId: string, isCorrect: boolean): Promise<void> {
+    const response = await api.fetch(
+      'tome-ms-language',
+      `/tomelang/sessions/${sessionId}/answers`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entityId: wordId, isCorrect }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to submit answer (${response.status})`);
+    }
   }
 
-  async completeSession(_sessionId: string): Promise<SessionSummary> {
-    throw new Error('Not implemented — backend API contract pending');
+  async completeSession(sessionId: string): Promise<SessionSummary> {
+    const response = await api.fetch(
+      'tome-ms-language',
+      `/tomelang/sessions/${sessionId}/completion`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to complete session (${response.status})`);
+    }
+
+    const summary: SessionSummary = await response.json();
+
+    localStorage.removeItem(queueStateKey(sessionId));
+
+    return summary;
   }
 }

--- a/api/TomeVocabularyPracticeAPI.ts
+++ b/api/TomeVocabularyPracticeAPI.ts
@@ -75,7 +75,7 @@ export class TomeVocabularyPracticeAPI implements IVocabularyPracticeAPI {
   async startSession(language: string): Promise<VocabPracticeSession> {
     const response = await api.fetch(
       'tome-ms-language',
-      `/tomelang/languages/${language}/sessions`,
+      `/languages/${language}/sessions`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -100,7 +100,7 @@ export class TomeVocabularyPracticeAPI implements IVocabularyPracticeAPI {
   }
 
   async getActiveSession(): Promise<VocabPracticeSession | null> {
-    const response = await api.fetch('tome-ms-language', '/tomelang/sessions/active');
+    const response = await api.fetch('tome-ms-language', '/sessions/active');
 
     if (response.status === 404) return null;
     if (!response.ok) {
@@ -131,7 +131,7 @@ export class TomeVocabularyPracticeAPI implements IVocabularyPracticeAPI {
   async submitAnswer(sessionId: string, wordId: string, isCorrect: boolean): Promise<void> {
     const response = await api.fetch(
       'tome-ms-language',
-      `/tomelang/sessions/${sessionId}/answers`,
+      `/sessions/${sessionId}/answers`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -147,7 +147,7 @@ export class TomeVocabularyPracticeAPI implements IVocabularyPracticeAPI {
   async completeSession(sessionId: string): Promise<SessionSummary> {
     const response = await api.fetch(
       'tome-ms-language',
-      `/tomelang/sessions/${sessionId}/completion`,
+      `/sessions/${sessionId}/completion`,
       { method: 'POST', headers: { 'Content-Type': 'application/json' } }
     );
 

--- a/api/VocabularyPracticeAPIFactory.ts
+++ b/api/VocabularyPracticeAPIFactory.ts
@@ -3,8 +3,9 @@ import { MockVocabularyPracticeAPI } from './MockVocabularyPracticeAPI';
 import { TomeVocabularyPracticeAPI } from './TomeVocabularyPracticeAPI';
 
 export function getVocabularyPracticeAPI(): IVocabularyPracticeAPI {
-  if (process.env.NEXT_PUBLIC_VOCAB_PRACTICE_MOCK === 'true') {
+  
+  if (process.env.NEXT_PUBLIC_VOCAB_PRACTICE_MOCK === 'true') 
     return new MockVocabularyPracticeAPI();
-  }
+  
   return new TomeVocabularyPracticeAPI();
 }

--- a/app/language-learning/summary/page.tsx
+++ b/app/language-learning/summary/page.tsx
@@ -49,8 +49,8 @@ export default function SessionSummaryPage() {
         <div className="flex flex-1 flex-col items-stretch px-6 py-8 gap-8">
             {/* Score summary */}
             <div className="flex flex-col items-center gap-4">
-                <div className="text-6xl font-bold text-primary">{summary.accuracy}%</div>
-                <div className="text-muted-foreground text-sm">Accuracy</div>
+                <div className="text-muted-foreground text-xs uppercase tracking-widest">You scored</div>
+                <div className="text-4xl font-bold text-primary">{summary.accuracy}%</div>
 
                 <div className="flex gap-8 mt-2">
                     <div className="flex flex-col items-center">
@@ -58,7 +58,7 @@ export default function SessionSummaryPage() {
                         <span className="text-xs text-muted-foreground uppercase tracking-wide">Total Words</span>
                     </div>
                     <div className="flex flex-col items-center">
-                        <span className="text-2xl font-semibold text-green-600">{summary.firstAttemptCorrect}</span>
+                        <span className="text-2xl font-semibold text-green-300">{summary.firstAttemptCorrect}</span>
                         <span className="text-xs text-muted-foreground uppercase tracking-wide">First Attempt</span>
                     </div>
                 </div>
@@ -67,26 +67,26 @@ export default function SessionSummaryPage() {
             {/* Words with errors */}
             {failedWords.length > 0 && (
                 <div className="flex flex-col gap-3">
-                    <h2 className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+                    <div className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
                         Words to Review
-                    </h2>
-                    <ul className="flex flex-col gap-2">
+                    </div>
+                    <div className="flex flex-col gap-1">
                         {failedWords.map((w) => (
-                            <li
+                            <div
                                 key={w.wordId}
-                                className="flex justify-between items-center bg-muted rounded-lg px-4 py-3"
+                                className="flex justify-between items-center bg-muted rounded-lg"
                             >
-                                <span className="text-sm">
+                                <span className="text-base">
                                     <span className="font-medium">{w.english}</span>
                                     <span className="text-muted-foreground"> → </span>
                                     <span className="font-medium">{w.translation}</span>
                                 </span>
-                                <span className="text-xs text-red-500">
-                                    {w.failedAttempts} {w.failedAttempts === 1 ? 'mistake' : 'mistakes'}
+                                <span className="text-sm text-red-800">
+                                    <span className="font-bold">{w.failedAttempts}</span> {w.failedAttempts === 1 ? 'mistake' : 'mistakes'}
                                 </span>
-                            </li>
+                            </div>
                         ))}
-                    </ul>
+                    </div>
                 </div>
             )}
 
@@ -96,7 +96,6 @@ export default function SessionSummaryPage() {
                     svgIconPath={{ src: "/images/home.svg", alt: "Return to Language Learning" }}
                     onClick={() => router.push('/language-learning')}
                 />
-                <span className="text-xs text-muted-foreground">Return to Language Learning</span>
             </div>
         </div>
     );

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -154,7 +154,7 @@ export default function VocabularyPracticePage() {
          * Move to the next question
          */
         const next = () => {
-            
+
             setMasteredIds(nextMastered);
             setDeferredIds(nextDeferred);
             setFirstAttemptCorrectIds(nextFirstAttempt);
@@ -246,7 +246,7 @@ export default function VocabularyPracticePage() {
                         ) : (
                             /* Result view */
                             <div className="flex flex-col items-stretch gap-3 text-center">
-                                <span className="text-3xl font-bold text-foreground">
+                                <span className="text-3xl font-bold text-foreground mb-4">
                                     {currentWord.english}
                                 </span>
                                 <Result type={result.isCorrect ? "correct" : "incorrect"} text={result.userAnswer} title="Your answer" />
@@ -283,7 +283,7 @@ function Result({ type, text, title }: { type: "correct" | "incorrect" | "refere
     else if (type === 'reference') imageUrl = '/images/point-right.svg';
 
     return (
-        <div className='flex flex-col items-stretch my-1'>
+        <div className='flex flex-col items-stretch'>
             {/* <div className="text-2xs uppercase tracking-widest text-left pl-2 mb-1">{title}</div> */}
             <div className={`flex rounded-md items-center px-4 py-2 border-2 ${type === 'correct' ? 'border-green-800 text-green-800' : type === 'incorrect' ? 'border-red-800 text-red-800' : 'border-cyan-400 text-cyan-200'}`}>
                 <div className="pr-4">

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -49,7 +49,7 @@ export default function VocabularyPracticePage() {
         try {
             let s = await api.getActiveSession();
             if (!s) {
-                s = await api.startSession();
+                s = await api.startSession('danish');
             }
             setSession(s);
             setPendingQueue(s.pendingQueue);
@@ -105,60 +105,72 @@ export default function VocabularyPracticePage() {
             userAnswer.toLowerCase() === word.translation.toLowerCase();
 
         setResult({ isCorrect, userAnswer });
-        api.submitAnswer(session.sessionId, word.id, isCorrect).catch(console.error);
+
+        // Compute next queue state eagerly so we can persist to localStorage immediately
+        // (before the UI-delay timeout fires), ensuring resume works even if the user exits
+        // during the result feedback pause.
+        let nextPending: string[];
+        let nextMastered: string[];
+        let nextDeferred: string[];
+        let nextFirstAttempt: string[];
+        let nextFailedAttempts: Record<string, number>;
+
+        const currentFailedAttempts = Object.fromEntries(
+            session.words.map((w) => [w.id, w.failedAttempts])
+        );
+
+        if (isCorrect) {
+            const isFirstAttempt = !deferredIds.includes(word.id);
+            nextMastered = [...masteredIds, word.id];
+            nextFirstAttempt = isFirstAttempt ? [...firstAttemptCorrectIds, word.id] : firstAttemptCorrectIds;
+            nextPending = pendingQueue.slice(1);
+            nextDeferred = deferredIds.filter((id) => id !== word.id);
+            nextFailedAttempts = currentFailedAttempts;
+        } else {
+            nextDeferred = deferredIds.includes(word.id) ? deferredIds : [...deferredIds, word.id];
+            nextPending = [...pendingQueue.slice(1), word.id];
+            nextMastered = masteredIds;
+            nextFirstAttempt = firstAttemptCorrectIds;
+            nextFailedAttempts = { ...currentFailedAttempts, [word.id]: (currentFailedAttempts[word.id] ?? 0) + 1 };
+        }
+
+        // Persist to localStorage immediately (not waiting for the UI timer)
+        const queueState = {
+            sessionId: session.sessionId,
+            pendingQueue: nextPending,
+            masteredIds: nextMastered,
+            deferredIds: nextDeferred,
+            firstAttemptCorrectIds: nextFirstAttempt,
+            wordFailedAttempts: nextFailedAttempts,
+        };
+        localStorage.setItem(`vocab-queue-${session.sessionId}`, JSON.stringify(queueState));
+
+        // Fire-and-forget backend call — errors logged but do not block UX
+        api.submitAnswer(session.sessionId, word.id, isCorrect).catch((e) => {
+            console.error('submitAnswer failed:', e);
+        });
 
         const timer = setTimeout(() => {
-            if (isCorrect) {
-                const isFirstAttempt = !deferredIds.includes(word.id);
-                const newMastered = [...masteredIds, word.id];
-                const newFirstAttempt = isFirstAttempt
-                    ? [...firstAttemptCorrectIds, word.id]
-                    : firstAttemptCorrectIds;
-                const newPending = pendingQueue.slice(1);
-                // Remove from deferred now that the word is mastered
-                const newDeferred = deferredIds.filter((id) => id !== word.id);
+            setMasteredIds(nextMastered);
+            setDeferredIds(nextDeferred);
+            setFirstAttemptCorrectIds(nextFirstAttempt);
+            setPendingQueue(nextPending);
 
-                setMasteredIds(newMastered);
-                setDeferredIds(newDeferred);
-                setFirstAttemptCorrectIds(newFirstAttempt);
-                setPendingQueue(newPending);
+            setSession((prev) => {
+                if (!prev) return prev;
+                return {
+                    ...prev,
+                    words: prev.words.map((w) => ({
+                        ...w,
+                        failedAttempts: nextFailedAttempts[w.id] ?? w.failedAttempts,
+                    })),
+                    masteredIds: nextMastered,
+                    deferredIds: nextDeferred,
+                    firstAttemptCorrectIds: nextFirstAttempt,
+                    pendingQueue: nextPending,
+                };
+            });
 
-                // Update session state for completeSession accuracy
-                setSession((prev) => {
-                    if (!prev) return prev;
-                    return {
-                        ...prev,
-                        masteredIds: newMastered,
-                        deferredIds: newDeferred,
-                        firstAttemptCorrectIds: newFirstAttempt,
-                        pendingQueue: newPending,
-                    };
-                });
-            } else {
-                // Move to end of queue, add to deferred if not already
-                const newDeferred = deferredIds.includes(word.id)
-                    ? deferredIds
-                    : [...deferredIds, word.id];
-                const newPending = [...pendingQueue.slice(1), word.id];
-
-                // Increment failedAttempts in local session state
-                setSession((prev) => {
-                    if (!prev) return prev;
-                    return {
-                        ...prev,
-                        words: prev.words.map((w) =>
-                            w.id === word.id
-                                ? { ...w, failedAttempts: w.failedAttempts + 1 }
-                                : w
-                        ),
-                        deferredIds: newDeferred,
-                        pendingQueue: newPending,
-                    };
-                });
-
-                setDeferredIds(newDeferred);
-                setPendingQueue(newPending);
-            }
             setResult(null);
             setAnswer('');
         }, isCorrect ? 1000 : 3000);

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -7,7 +7,7 @@ import { getVocabularyPracticeAPI } from '@/api/VocabularyPracticeAPIFactory';
 import { VocabPracticeSession, VocabPracticeWord } from '@/model/VocabularyPractice';
 import { SessionProgressBar } from '@/components/SessionProgressBar';
 import { TranslationInput } from '@/components/TranslationInput';
-import { MaskedSvgIcon } from 'toto-react';
+import { MaskedSvgIcon, RoundButton } from 'toto-react';
 
 type ResultState = { isCorrect: boolean; userAnswer: string } | null;
 
@@ -29,6 +29,8 @@ export default function VocabularyPracticePage() {
     const [result, setResult] = useState<ResultState>(null);
 
     const inputRef = useRef<HTMLTextAreaElement>(null);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const nextFnRef = useRef<(() => void) | null>(null);
     const api = getVocabularyPracticeAPI();
 
     // Configure header
@@ -179,9 +181,18 @@ export default function VocabularyPracticePage() {
             setAnswer('');
         }
 
-        const timer = setTimeout(next, isCorrect ? 1000 : 3000);
+        nextFnRef.current = next;
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(next, isCorrect ? 1000 : 10000);
 
-        return () => clearTimeout(timer);
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current);
+        };
+    };
+
+    const handleNext = () => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        nextFnRef.current?.();
     };
 
     // ---- Render states ----
@@ -259,14 +270,25 @@ export default function VocabularyPracticePage() {
 
             {/* Input pinned at bottom */}
             <div className="fixed bottom-0 left-0 right-0 p-4 bg-background border-t border-border">
-                <TranslationInput
-                    ref={inputRef}
-                    value={answer}
-                    onChange={setAnswer}
-                    onSubmit={handleSubmit}
-                    disabled={result !== null}
-                    placeholder="Type Danish translation…"
-                />
+                <div className="flex items-center gap-3">
+                    <div className="flex-1 min-w-0">
+                        <TranslationInput
+                            ref={inputRef}
+                            value={answer}
+                            onChange={setAnswer}
+                            onSubmit={handleSubmit}
+                            disabled={result !== null}
+                            placeholder="Type Danish translation…"
+                        />
+                    </div>
+                    <div className={`transition-all duration-300 overflow-hidden flex items-center justify-center pb-1 ${result !== null && !result.isCorrect ? 'w-12 opacity-100' : 'w-0 opacity-0'}`}>
+                        <RoundButton
+                            svgIconPath={{ src: '/images/point-right.svg', alt: 'Next', color: 'bg-lime-200' }}
+                            onClick={handleNext}
+                            type="primary"
+                        />
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -150,7 +150,11 @@ export default function VocabularyPracticePage() {
             console.error('submitAnswer failed:', e);
         });
 
-        const timer = setTimeout(() => {
+        /**
+         * Move to the next question
+         */
+        const next = () => {
+            
             setMasteredIds(nextMastered);
             setDeferredIds(nextDeferred);
             setFirstAttemptCorrectIds(nextFirstAttempt);
@@ -173,7 +177,9 @@ export default function VocabularyPracticePage() {
 
             setResult(null);
             setAnswer('');
-        }, isCorrect ? 1000 : 300000);
+        }
+
+        const timer = setTimeout(next, isCorrect ? 1000 : 3000);
 
         return () => clearTimeout(timer);
     };
@@ -243,29 +249,8 @@ export default function VocabularyPracticePage() {
                                 <span className="text-3xl font-bold text-foreground">
                                     {currentWord.english}
                                 </span>
-                                <div className={`flex rounded-full items-center px-4 py-2 ${result.isCorrect ? 'bg-green-800 text-green-200' : 'bg-red-800 text-red-200'}`}>
-                                    <div className="pr-4">
-                                        <MaskedSvgIcon src={result.isCorrect ? '/images/tick.svg' : '/images/close.svg'} size='w-5 h-5' alt='Result Icon' color={result.isCorrect ? 'bg-green-100' : 'bg-red-200'} />
-                                    </div>
-                                    <div className="flex-1 flex flex-col items-start justify-center pl-4 border-l-4 border-[var(--background)] self-stretch -my-2 py-2">
-                                        <div className="text-2xs uppercase tracking-widest">Your answer:</div>
-                                        <div>{result.userAnswer || <em className="text-muted-foreground">empty</em>}</div>
-                                    </div>
-                                    {/* <div className="flex-1 flex flex-col items-start justify-center border-l-4 border-[var(--background)] self-stretch -my-2 py-2 pl-4">
-                                        <div className="text-2xs uppercase tracking-widest">Correct:</div>
-                                        <div>{currentWord.translation}</div>
-                                    </div> */}
-                                </div>
-                                {!result.isCorrect && (
-                                    <div className="flex flex-col items-center gap-4 mt-4">
-                                        <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-                                            Correct translation:
-                                        </span>
-                                        <div className="text-4xl font-bold text-foreground">
-                                            {currentWord.translation}
-                                        </div>
-                                    </div>
-                                )}
+                                <Result type={result.isCorrect ? "correct" : "incorrect"} text={result.userAnswer} title="Your answer" />
+                                {!result.isCorrect && (<Result type="reference" text={currentWord.translation} title="Correct translation" />)}
                             </div>
                         )}
                     </>
@@ -285,4 +270,29 @@ export default function VocabularyPracticePage() {
             </div>
         </div>
     );
+}
+
+function Result({ type, text, title }: { type: "correct" | "incorrect" | "reference"; text: string, title: string }) {
+
+    let imageUrl = '/images/close.svg';
+    let iconSize = 'w-5 h-5';
+    if (type === 'correct') {
+        imageUrl = '/images/tick.svg';
+        iconSize = 'w-8 h-8';
+    }
+    else if (type === 'reference') imageUrl = '/images/point-right.svg';
+
+    return (
+        <div className='flex flex-col items-stretch my-1'>
+            {/* <div className="text-2xs uppercase tracking-widest text-left pl-2 mb-1">{title}</div> */}
+            <div className={`flex rounded-md items-center px-4 py-2 border-2 ${type === 'correct' ? 'border-green-800 text-green-800' : type === 'incorrect' ? 'border-red-800 text-red-800' : 'border-cyan-400 text-cyan-200'}`}>
+                <div className="pr-4">
+                    <MaskedSvgIcon src={imageUrl} size={iconSize} alt='Result Icon' color={type === 'correct' ? 'bg-green-800' : type === 'incorrect' ? 'bg-red-800' : 'bg-cyan-300'} />
+                </div>
+                <div className="flex-1 flex flex-col items-start justify-center pl-4 border-l-4 border-[var(--background)] self-stretch -my-2 py-2">
+                    <div>{text || <em className="text-muted-foreground">empty</em>}</div>
+                </div>
+            </div>
+        </div>
+    )
 }

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -260,8 +260,8 @@ export default function VocabularyPracticePage() {
                                 <span className="text-3xl font-bold text-foreground mb-4">
                                     {currentWord.english}
                                 </span>
-                                <Result type={result.isCorrect ? "correct" : "incorrect"} text={result.userAnswer} title="Your answer" />
-                                {!result.isCorrect && (<Result type="reference" text={currentWord.translation} title="Correct translation" />)}
+                                <Result type={result.isCorrect ? "correct" : "incorrect"} text={result.userAnswer} />
+                                {!result.isCorrect && (<Result type="reference" text={currentWord.translation} />)}
                             </div>
                         )}
                     </>
@@ -294,7 +294,7 @@ export default function VocabularyPracticePage() {
     );
 }
 
-function Result({ type, text, title }: { type: "correct" | "incorrect" | "reference"; text: string, title: string }) {
+function Result({ type, text }: { type: "correct" | "incorrect" | "reference"; text: string}) {
 
     let imageUrl = '/images/close.svg';
     let iconSize = 'w-5 h-5';

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -173,7 +173,7 @@ export default function VocabularyPracticePage() {
 
             setResult(null);
             setAnswer('');
-        }, isCorrect ? 1000 : 3000);
+        }, isCorrect ? 1000 : 300000);
 
         return () => clearTimeout(timer);
     };
@@ -231,7 +231,7 @@ export default function VocabularyPracticePage() {
                             /* Word prompt */
                             <div className="flex flex-col items-center gap-4">
                                 <span className="text-sm font-semibold tracking-widest text-muted-foreground uppercase">
-                                    Translate
+                                    Translate this word
                                 </span>
                                 <span className="text-4xl font-bold text-foreground">
                                     {currentWord.english}

--- a/docs/specs/language-learning/home-page.md
+++ b/docs/specs/language-learning/home-page.md
@@ -22,9 +22,14 @@ This section contains a **single action button**. Its label and behaviour depend
 
 ### Detecting an ongoing practice
 
-On page load, the app must call the backend to check whether the current user has an active (unfinished) language-learning session.
+On page load, the app calls `GET /tomelang/sessions/active` (via `IVocabularyPracticeAPI.getActiveSession()`) to check whether the current user has an active session.
 
-> **⚠️ Spec gap — API endpoint needed.** The endpoint and response format for checking ongoing language-learning sessions must be defined and added here before this can be implemented.
+| Response | Meaning | Button shown |
+|----------|---------|--------------|
+| `200 OK` (session object) | User has an active session | **Resume Practice** |
+| `404 Not Found` | No active session | **Start Practice** |
+
+While the check is in progress, a loading indicator is shown in place of the button.
 
 ---
 

--- a/docs/specs/language-learning/vocabulary-practice.md
+++ b/docs/specs/language-learning/vocabulary-practice.md
@@ -6,9 +6,9 @@ Vocabulary Practice is a language-learning feature that trains the user to recal
 
 The target language currently supported is **Danish**.
 
-All session content — vocabulary items and expected answers — is **generated and supplied by the backend API**. The app is responsible only for presenting challenges and processing responses.
+All session content — vocabulary items and expected answers — is **generated and supplied by the backend API** (`tome-ms-language`). The app is responsible only for presenting challenges, processing responses, and managing session queue state locally.
 
-## Mock interface
+## UI Reference
 
 ![Practice a single word](drawings/vocab-practice.png)
 
@@ -26,11 +26,27 @@ A **loading spinner** is displayed while the session data is being fetched from 
 
 ## Session Persistence & Resuming
 
-Sessions are **persisted on the backend**. If the user exits a session before completing it (e.g. by tapping the back button), the session remains open on the server and can be resumed later.
+Sessions are **persisted on the backend** (`tome-ms-language`). If the user exits a session before completing it (e.g. by tapping the back button), the session remains open on the server and can be resumed later.
 
 The Language Learning home page detects whether an active session exists for the current user and presents a **Resume Practice** button in place of the Start button. See the [Language Learning Home Page spec](./home-page.md) for details.
 
-When resuming, the backend restores the **exact queue state** — including which word was current, which words are still pending, and which are deferred. The app loads this state and resumes from where the user left off. A loading spinner is displayed while the session state is being fetched.
+### What the backend stores vs. what the frontend manages
+
+| Data | Stored by | Notes |
+|------|-----------|-------|
+| Session ID, language, word list, total words | **Backend** | Retrieved via `GET /sessions/active` |
+| Individual submitted answers (per word, correct/incorrect) | **Backend** | Stored on each `submitAnswer` call |
+| Queue state: pending, mastered, deferred, first-attempt-correct, failed-attempt counts | **Frontend** (localStorage) | Persisted in `localStorage` under key `vocab-queue-{sessionId}` |
+
+The backend does **not** store or return queue state. Queue state is managed entirely on the client and persisted to `localStorage` so it survives navigation and page reloads.
+
+### Resume flow
+
+1. The app calls `getActiveSession()`.
+2. If the backend returns an active session, the API class reads queue state from `localStorage` using key `vocab-queue-{sessionId}`.
+3. If `localStorage` has state for that session: the existing queue state is restored and the user resumes exactly where they left off.
+4. If `localStorage` is empty (e.g. cleared by the user): the queue state is initialised fresh — all words placed in the pending queue, mastered/deferred lists empty. The user effectively restarts the word list (but the session ID on the backend is the same).
+5. A loading spinner is displayed while session state is being fetched.
 
 A user with an active session **cannot start a new session** until the active one is completed.
 
@@ -112,7 +128,7 @@ When a deferred (red) word is eventually answered correctly, its portion moves f
 
 Tapping the **back button** in the header during an active session exits the session immediately — no confirmation dialog is shown.
 
-The session state (current word, pending queue, deferred words) is **saved on the backend**. The user can return to it at any time via the **Resume Practice** button on the Language Learning home page. The progress bar state is also preserved.
+The **session** (word list) remains open on the backend. The **queue state** (pending, deferred, mastered words) is persisted to `localStorage` by the page component on every answer, so it is available when the user returns. The user can resume at any time via the **Resume Practice** button on the Language Learning home page.
 
 ---
 
@@ -130,16 +146,118 @@ The session state (current word, pending queue, deferred words) is **saved on th
 
 ## State Management
 
-| State | Description |
-|-------|-------------|
-| **Pending queue** | Words not yet answered correctly in this session |
-| **Mastered** | Words answered correctly; removed from the queue |
-| **Deferred** | Words answered incorrectly; appended to the end of the pending queue |
+| State | Description | Stored in |
+|-------|-------------|-----------|
+| **Pending queue** | Words not yet answered correctly in this session | React state + localStorage |
+| **Mastered** | Words answered correctly; removed from the queue | React state + localStorage |
+| **Deferred** | Words answered incorrectly; appended to the end of the pending queue | React state + localStorage |
+| **First-attempt correct IDs** | Words answered correctly on the first attempt | React state + localStorage |
+| **Failed attempts per word** | Count of wrong answers per word (used in the summary) | React state + localStorage |
 
-At any point during the session, the app must track:
-* The ordered pending queue
-* The number of items originally in the session
-* The number of items answered correctly on the first attempt (used on the summary screen)
+At any point during the session, the app must track all of the above. After each answer, the page component must **persist the current queue state to `localStorage`** under the key `vocab-queue-{sessionId}`, so that the session can be accurately resumed if the user navigates away.
+
+The stored object shape:
+
+```json
+{
+  "sessionId": "...",
+  "pendingQueue": ["wordId1", "wordId2"],
+  "masteredIds": ["wordId3"],
+  "deferredIds": [],
+  "firstAttemptCorrectIds": ["wordId3"],
+  "wordFailedAttempts": { "wordId1": 0, "wordId2": 1 }
+}
+```
+
+---
+
+## Backend API Integration
+
+### API interface: `IVocabularyPracticeAPI`
+
+All practice pages interact with the backend through the `IVocabularyPracticeAPI` interface, which has the following methods:
+
+```ts
+interface IVocabularyPracticeAPI {
+  startSession(language: string): Promise<VocabPracticeSession>;
+  getActiveSession(): Promise<VocabPracticeSession | null>;
+  submitAnswer(sessionId: string, wordId: string, isCorrect: boolean): Promise<void>;
+  completeSession(sessionId: string): Promise<SessionSummary>;
+}
+```
+
+Note: `startSession` takes a `language` parameter (e.g. `"danish"`). Currently only `"danish"` is supported.
+
+### Switching between mock and real backend
+
+The factory `VocabularyPracticeAPIFactory.getVocabularyPracticeAPI()` returns either:
+- **`MockVocabularyPracticeAPI`** when `NEXT_PUBLIC_VOCAB_PRACTICE_MOCK=true` (for development/testing without the backend)
+- **`TomeVocabularyPracticeAPI`** otherwise (production, using `tome-ms-language`)
+
+### `TomeVocabularyPracticeAPI` — method contracts
+
+All calls go to the `tome-ms-language` microservice via the `TotoAPI` wrapper (adds auth header, correlation ID, etc.).
+
+#### `startSession(language: string): Promise<VocabPracticeSession>`
+
+1. Call `POST /tomelang/languages/{language}/sessions` with body `{ "practiceType": "vocabulary" }`.
+2. On `409 Conflict`: the user already has an active session — surface an error to the user.
+3. Map the backend response to `VocabPracticeSession`:
+
+| Backend field | `VocabPracticeSession` field |
+|---------------|------------------------------|
+| `sessionId` | `sessionId` |
+| `payload.words[].wordId` | `words[].id` |
+| `payload.words[].english` | `words[].english` |
+| `payload.words[].translation` | `words[].translation` |
+| _(none — initialised to 0)_ | `words[].failedAttempts` |
+| `payload.words` (all, in order) | `pendingQueue` (initial: all word IDs) |
+| _(none — initialised empty)_ | `masteredIds`, `deferredIds`, `firstAttemptCorrectIds` |
+| `payload.totalWords` | `totalWords` |
+
+4. Store the initial queue state in `localStorage` under key `vocab-queue-{sessionId}`.
+5. Return the `VocabPracticeSession`.
+
+#### `getActiveSession(): Promise<VocabPracticeSession | null>`
+
+1. Call `GET /tomelang/sessions/active`.
+2. If `404`: return `null` (no active session).
+3. If `200`: map backend response to `VocabPracticeSession` (same field mapping as above).
+4. Read queue state from `localStorage` under key `vocab-queue-{sessionId}`:
+   - **If found**: restore `pendingQueue`, `masteredIds`, `deferredIds`, `firstAttemptCorrectIds`, and per-word `failedAttempts`.
+   - **If not found** (localStorage cleared): initialise fresh — all words in `pendingQueue`, everything else empty, all `failedAttempts = 0`.
+5. Return the `VocabPracticeSession`.
+
+#### `submitAnswer(sessionId: string, wordId: string, isCorrect: boolean): Promise<void>`
+
+1. Call `POST /tomelang/sessions/{sessionId}/answers` with body `{ "entityId": wordId, "isCorrect": isCorrect }`.
+2. Returns when the call completes (the page handles queue-state updates in React state).
+3. Note: queue state persistence to `localStorage` is the **page component's responsibility** (not this method's).
+
+#### `completeSession(sessionId: string): Promise<SessionSummary>`
+
+1. Call `POST /tomelang/sessions/{sessionId}/completion`.
+2. The backend response maps directly to `SessionSummary` — no transformation needed:
+
+| Backend field | `SessionSummary` field |
+|---------------|------------------------|
+| `totalWords` | `totalWords` |
+| `firstAttemptCorrect` | `firstAttemptCorrect` |
+| `accuracy` | `accuracy` |
+| `wordResults[].wordId` | `wordResults[].wordId` |
+| `wordResults[].english` | `wordResults[].english` |
+| `wordResults[].translation` | `wordResults[].translation` |
+| `wordResults[].failedAttempts` | `wordResults[].failedAttempts` |
+
+3. Remove the queue state entry from `localStorage` (`vocab-queue-{sessionId}`).
+4. Return the `SessionSummary`.
+
+### Queue state persistence responsibility
+
+- **`startSession()`** initialises and writes queue state to localStorage.
+- **`getActiveSession()`** reads queue state from localStorage.
+- **The page component** must write updated queue state to localStorage after each answer (e.g. in a `useEffect` that fires when `pendingQueue`, `masteredIds`, `deferredIds`, `firstAttemptCorrectIds`, or word `failedAttempts` change).
+- **`completeSession()`** clears queue state from localStorage.
 
 ---
 

--- a/public/images/point-right.svg
+++ b/public/images/point-right.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.83934 0L1.88909 3.95024C0.679525 5.1598 0 6.80032 0 8.5109C0 12.073 2.88765 14.9606 6.44974 14.9606L9 14.9606L11 7.96065H16V4.96065L5.12133 4.96065L7.96066 2.12132L5.83934 0Z" fill="#000000"/>
+</svg>


### PR DESCRIPTION
## Summary

Replaces the mock-only vocabulary practice implementation with a real integration against the `tome-ms-language` backend, while keeping the mock working for development.

Closes #210, #211, #212

---

## Changes

### `api/IVocabularyPracticeAPI.ts` (#210)
- Added `language: string` parameter to `startSession()`

### `api/MockVocabularyPracticeAPI.ts` (#210)
- Re-architected to mirror the real backend contract
- localStorage split into two keys: `vocab-active-session` (session metadata) and `vocab-queue-{sessionId}` (queue state)
- `submitAnswer()` is now a no-op — queue state management is the page component's responsibility
- `completeSession()` reads final queue state from localStorage to compute the summary
- `getActiveSession()` restores session + queue state from localStorage, falling back to fresh queue if localStorage was cleared

### `api/TomeVocabularyPracticeAPI.ts` (#211)
- Fully implemented all 4 methods via `TotoAPI`:
  - `startSession(language)` → `POST /tomelang/languages/{language}/sessions`
  - `getActiveSession()` → `GET /tomelang/sessions/active`  
  - `submitAnswer()` → `POST /tomelang/sessions/{sessionId}/answers`
  - `completeSession()` → `POST /tomelang/sessions/{sessionId}/completion`
- Handles 404 (no active session) and 409 (conflict — active session exists)
- localStorage queue state initialised on `startSession`, restored on `getActiveSession`, cleared on `completeSession`

### `app/language-learning/vocabulary-practice/page.tsx` (#212)
- Passes `'danish'` to `startSession()`
- Refactored `handleSubmit` to compute next queue state eagerly and persist it to `localStorage['vocab-queue-{sessionId}']` **synchronously at submit time** (before the UI result-pause timeout), so the session can be resumed accurately even if the user exits during the feedback delay