### PR TITLE
feat: learning stats bar chart (rolling 7-day window)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,21 @@
 ## Style guide for front-end development
 ### Buttons
 - For buttons always use `RoundButton` from the `toto-react` library. **Do not** invent your own button style.
+
+### APIs
+All Backend APIs used must be wrapped by an API class in the `/api` folder. <br>
+Example: 
+```
+export class TomeLanguageAPI {
+
+    /**
+     * Fetches the vocabulary for the specified language
+     */
+    async getVocabulary(language: string): Promise<GetVocabularyResponse> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}`)).json();
+    }
+}
+```
+
+Important rules: 
+- The path **must not** include the basepath of the microservice. The basepath needs to be in the Config file, so contained in the `NEXT_PUBLIC_<..>_API_ENDPOINT` that corresponds to the microservice. In the above example its `/vocabulary/${language}` not `/tomelang/vocabulary/${language}` as `/tomelang` is the basepath of the microservice.

--- a/api/TomeLanguageAPI.ts
+++ b/api/TomeLanguageAPI.ts
@@ -9,6 +9,14 @@ export class TomeLanguageAPI {
         return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}`)).json();
     }
 
+    /**
+     * Fetches per-day completed session counts for the last N calendar days, inclusive today.
+     * Days with no completed sessions have count: 0.
+     */
+    async getRollingStats(days = 7): Promise<{ days: Array<{ date: string; count: number }> }> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/tomelang/sessions/stats/rolling?days=${days}`)).json();
+    }
+
 }
 
 export interface Word {

--- a/api/TomeLanguageAPI.ts
+++ b/api/TomeLanguageAPI.ts
@@ -14,7 +14,7 @@ export class TomeLanguageAPI {
      * Days with no completed sessions have count: 0.
      */
     async getRollingStats(days = 7): Promise<{ days: Array<{ date: string; count: number }> }> {
-        return (await new TotoAPI().fetch('tome-ms-language', `/tomelang/sessions/stats/rolling?days=${days}`)).json();
+        return (await new TotoAPI().fetch('tome-ms-language', `/sessions/stats/rolling?days=${days}`)).json();
     }
 
 }

--- a/api/TomeVocabularyPracticeAPI.ts
+++ b/api/TomeVocabularyPracticeAPI.ts
@@ -84,7 +84,9 @@ export class TomeVocabularyPracticeAPI implements IVocabularyPracticeAPI {
     );
 
     if (response.status === 409) {
-      throw new Error('You already have an active session. Please complete or resume it before starting a new one.');
+      const existing = await this.getActiveSession();
+      if (existing) return existing;
+      throw new Error('An active session already exists but could not be retrieved.');
     }
     if (!response.ok) {
       throw new Error(`Failed to start session (${response.status})`);

--- a/app/language-learning/page.tsx
+++ b/app/language-learning/page.tsx
@@ -46,7 +46,7 @@ export default function LanguageLearningPage() {
 
     return (
         <div className="flex flex-1 flex-col items-stretch justify-start">
-            <div className="flex-1 app-content flex flex-col px-4">
+            <div className="flex-1 flex flex-col px-4">
                 {/* Practice Buttons section */}
                 <div className="flex items-center justify-center mt-8 gap-4">
                     {/* Vocabulary list button */}
@@ -69,8 +69,10 @@ export default function LanguageLearningPage() {
                     )}
                 </div>
 
+                <div className="flex-1"></div>
+
                 {/* Learning Stats section */}
-                <div className="mt-8">
+                <div className="mt-8 mb-6">
                     {rollingStats === null ? (
                         <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height: 160 }}>
                             Loading stats…

--- a/app/language-learning/page.tsx
+++ b/app/language-learning/page.tsx
@@ -5,12 +5,16 @@ import { useRouter } from "next/navigation";
 import { useHeader } from "@/context/HeaderContext";
 import { RoundButton } from "toto-react";
 import { getVocabularyPracticeAPI } from "@/api/VocabularyPracticeAPIFactory";
+import { TomeLanguageAPI } from "@/api/TomeLanguageAPI";
+import { DayStat, LanguageLearningWeeklyStats } from "@/components/graph/LanguageLearningWeeklyStats";
 
 export default function LanguageLearningPage() {
 
     const router = useRouter();
     const { setConfig } = useHeader();
     const [hasActiveSession, setHasActiveSession] = useState<boolean | null>(null);
+    // null = loading, [] = error/empty, populated = data ready
+    const [rollingStats, setRollingStats] = useState<DayStat[] | null>(null);
 
     useEffect(() => {
         setConfig({
@@ -27,6 +31,13 @@ export default function LanguageLearningPage() {
             .getActiveSession()
             .then((session) => setHasActiveSession(session !== null))
             .catch(() => setHasActiveSession(false));
+    }, []);
+
+    useEffect(() => {
+        new TomeLanguageAPI()
+            .getRollingStats(7)
+            .then((res) => setRollingStats(res.days))
+            .catch(() => setRollingStats([]));
     }, []);
 
     const handlePracticeClick = () => {
@@ -59,8 +70,14 @@ export default function LanguageLearningPage() {
                 </div>
 
                 {/* Learning Stats section */}
-                <div>
-                    {/* TODO: Learning Stats */}
+                <div className="mt-8">
+                    {rollingStats === null ? (
+                        <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height: 160 }}>
+                            Loading stats…
+                        </div>
+                    ) : (
+                        <LanguageLearningWeeklyStats days={rollingStats} />
+                    )}
                 </div>
             </div>
         </div>

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -315,7 +315,7 @@ function Result({ type, text }: { type: "correct" | "incorrect" | "reference"; t
         <div className='flex flex-col items-stretch'>
             {/* <div className="text-2xs uppercase tracking-widest text-left pl-2 mb-1">{title}</div> */}
             <div className={`flex rounded-md items-center px-4 py-2 border-2 ${type === 'correct' ? 'border-green-800 text-green-800' : type === 'incorrect' ? 'border-red-800 text-red-800' : 'border-cyan-400 text-cyan-200'}`}>
-                <div className="pr-4">
+                <div className="">
                     <MaskedSvgIcon src={imageUrl} size={iconSize} alt='Result Icon' color={type === 'correct' ? 'bg-green-800' : type === 'incorrect' ? 'bg-red-800' : 'bg-cyan-300'} />
                 </div>
                 <div className="flex-1 flex flex-col items-start justify-center pl-4 border-l-4 border-[var(--background)] self-stretch -my-2 py-2">

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -37,6 +37,10 @@ export default function VocabularyPracticePage() {
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const nextFnRef = useRef<(() => void) | null>(null);
+    // Tracks the "generation" of the current loadSession call so stale concurrent
+    // invocations (e.g. React StrictMode double-fire) are discarded before they
+    // can call startSession and accidentally create a duplicate backend session.
+    const sessionLoadGenRef = useRef(0);
     const api = getVocabularyPracticeAPI();
 
     // Configure header
@@ -52,12 +56,15 @@ export default function VocabularyPracticePage() {
 
     // Load or start session on mount
     const loadSession = useCallback(async () => {
+        const gen = ++sessionLoadGenRef.current;
         setLoading(true);
         setError(null);
         try {
             let s = await api.getActiveSession();
+            if (sessionLoadGenRef.current !== gen) return; // superseded — discard
             if (!s) {
                 s = await api.startSession('danish');
+                if (sessionLoadGenRef.current !== gen) return; // superseded — discard
             }
             setSession(s);
             setPendingQueue(s.pendingQueue);
@@ -65,14 +72,18 @@ export default function VocabularyPracticePage() {
             setDeferredIds(s.deferredIds);
             setFirstAttemptCorrectIds(s.firstAttemptCorrectIds);
         } catch (e) {
+            if (sessionLoadGenRef.current !== gen) return;
             setError((e as Error).message ?? 'Failed to load session');
         } finally {
-            setLoading(false);
+            if (sessionLoadGenRef.current === gen) setLoading(false);
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         loadSession();
+        // Increment the generation counter on cleanup so any in-flight loadSession
+        // call from this invocation is treated as stale and will not call startSession.
+        return () => { sessionLoadGenRef.current++; };
     }, [loadSession]);
 
     // Auto-clear and auto-focus when current word changes

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -11,6 +11,12 @@ import { MaskedSvgIcon, RoundButton } from 'toto-react';
 
 type ResultState = { isCorrect: boolean; userAnswer: string } | null;
 
+function normalizeTranslationForComparison(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/[\.\s'’]/g, '');
+}
+
 export default function VocabularyPracticePage() {
     const router = useRouter();
     const { setConfig } = useHeader();
@@ -99,12 +105,13 @@ export default function VocabularyPracticePage() {
 
     const handleSubmit = () => {
         if (result !== null) return; // already showing result
+        if (!answer.trim()) return;
         const word = getCurrentWord();
         if (!word || !session) return;
 
         const userAnswer = answer.trim();
         const isCorrect =
-            userAnswer.toLowerCase() === word.translation.toLowerCase();
+            normalizeTranslationForComparison(userAnswer) === normalizeTranslationForComparison(word.translation);
 
         setResult({ isCorrect, userAnswer });
 

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -250,7 +250,7 @@ export default function VocabularyPracticePage() {
                                 <span className="text-sm font-semibold tracking-widest text-muted-foreground uppercase">
                                     Translate this word
                                 </span>
-                                <span className="text-4xl font-bold text-foreground">
+                                <span className="text-4xl font-bold text-foreground text-center">
                                     {currentWord.english}
                                 </span>
                             </div>

--- a/components/TranslationInput.tsx
+++ b/components/TranslationInput.tsx
@@ -27,7 +27,7 @@ export const TranslationInput = forwardRef<HTMLTextAreaElement, TranslationInput
         const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
-                if (!disabled) onSubmit();
+                if (!disabled && value.trim()) onSubmit();
             }
         };
 

--- a/components/graph/LanguageLearningWeeklyStats.tsx
+++ b/components/graph/LanguageLearningWeeklyStats.tsx
@@ -70,6 +70,30 @@ export function LanguageLearningWeeklyStats({ days }: { days: DayStat[] }) {
             .attr("y", d => y(d.count))
             .attr("height", d => baseline - y(d.count));
 
+        // Session count labels inside bars (near the top)
+        const sessionCountLabels = g.selectAll<SVGTextElement, DayStat>("text.session-count")
+            .data(days)
+            .enter()
+            .append("text")
+            .attr("class", "session-count")
+            .attr("x", d => x(d.date)! + x.bandwidth() / 2)
+            .attr("y", baseline)
+            .attr("text-anchor", "middle")
+            .attr("fill", "#a5f3fc")
+            .attr("font-size", 11)
+            .attr("font-weight", 600)
+            .text(d => d.count.toString());
+
+        sessionCountLabels.transition()
+            .duration(600)
+            .ease(d3.easeCubicOut)
+            .attr("y", d => {
+                const barTop = y(d.count);
+                const offset = 18;
+                // Keep labels inside short bars while preserving top-inside placement.
+                return Math.min(barTop + offset, baseline - 4);
+            });
+
         // X-axis day labels
         g.selectAll<SVGTextElement, DayStat>("text.day-label")
             .data(days)
@@ -79,9 +103,12 @@ export function LanguageLearningWeeklyStats({ days }: { days: DayStat[] }) {
             .attr("x", d => x(d.date)! + x.bandwidth() / 2)
             .attr("y", innerHeight + 20)
             .attr("text-anchor", "middle")
-            .attr("fill", "#94a3b8")
+            .attr("fill", "white")
             .attr("font-size", 11)
-            .text(d => moment(d.date, 'YYYYMMDD').format('ddd'));
+            .text(d => {
+                const day = moment(d.date, "YYYYMMDD").format("ddd");
+                return day.charAt(0).toUpperCase() + day.slice(1, 3).toLowerCase();
+            });
 
     }, [days, width]);
 

--- a/components/graph/LanguageLearningWeeklyStats.tsx
+++ b/components/graph/LanguageLearningWeeklyStats.tsx
@@ -1,0 +1,110 @@
+import * as d3 from "d3";
+import moment from "moment";
+import { useEffect, useRef, useState } from "react";
+
+export interface DayStat {
+    date: string;  // YYYYMMDD
+    count: number;
+}
+
+/**
+ * Bar chart showing the number of completed practice sessions per day.
+ * Accepts data as props so it is testable in isolation.
+ */
+export function LanguageLearningWeeklyStats({ days }: { days: DayStat[] }) {
+    const svgRef = useRef<SVGSVGElement | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [width, setWidth] = useState(0);
+    const height = 160;
+    const margin = { top: 20, right: 10, bottom: 30, left: 10 };
+
+    useEffect(() => {
+        function handleResize() {
+            if (containerRef.current) setWidth(containerRef.current.offsetWidth);
+        }
+        handleResize();
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
+
+    useEffect(() => {
+        if (!days || days.length === 0 || width === 0) return;
+
+        const svg = d3.select(svgRef.current);
+        svg.selectAll("*").remove();
+
+        const innerWidth  = width - margin.left - margin.right;
+        const innerHeight = height - margin.top - margin.bottom;
+
+        const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+
+        const x = d3.scaleBand()
+            .domain(days.map(d => d.date))
+            .range([0, innerWidth])
+            .paddingInner(0.35)
+            .paddingOuter(0.15);
+
+        const maxCount = Math.max(1, d3.max(days, d => d.count) ?? 0);
+        const y = d3.scaleLinear()
+            .domain([0, maxCount])
+            .range([innerHeight, 0]);
+
+        const baseline = y(0);
+
+        // Bars — start at baseline height=0 then animate up
+        const bars = g.selectAll<SVGRectElement, DayStat>("rect.bar")
+            .data(days)
+            .enter()
+            .append("rect")
+            .attr("class", "bar")
+            .attr("x", d => x(d.date)!)
+            .attr("width", x.bandwidth())
+            .attr("y", baseline)
+            .attr("height", 0)
+            .attr("fill", "#155e75")
+            .attr("rx", 3);
+
+        bars.transition()
+            .duration(600)
+            .ease(d3.easeCubicOut)
+            .attr("y", d => y(d.count))
+            .attr("height", d => baseline - y(d.count));
+
+        // X-axis day labels
+        g.selectAll<SVGTextElement, DayStat>("text.day-label")
+            .data(days)
+            .enter()
+            .append("text")
+            .attr("class", "day-label")
+            .attr("x", d => x(d.date)! + x.bandwidth() / 2)
+            .attr("y", innerHeight + 20)
+            .attr("text-anchor", "middle")
+            .attr("fill", "#94a3b8")
+            .attr("font-size", 11)
+            .text(d => moment(d.date, 'YYYYMMDD').format('ddd'));
+
+    }, [days, width]);
+
+    if (days.length === 0) {
+        return (
+            <div
+                ref={containerRef}
+                className="flex items-center justify-center text-sm text-muted-foreground"
+                style={{ width: "100%", height }}
+            >
+                No data yet
+            </div>
+        );
+    }
+
+    return (
+        <div ref={containerRef} style={{ width: "100%" }}>
+            <svg
+                ref={svgRef}
+                width={width}
+                height={height}
+                style={{ display: "block", width: "100%", height }}
+            />
+        </div>
+    );
+}

--- a/docs/specs/language-learning/home-page.md
+++ b/docs/specs/language-learning/home-page.md
@@ -35,21 +35,100 @@ While the check is in progress, a loading indicator is shown in place of the but
 
 ## Learning Stats
 
-The Learning Stats section is a **bar graph** (implemented with **d3.js**) showing how many practices were completed for each day of the current week (Monday to Sunday inclusive).
+The Learning Stats section is a **bar graph** (implemented with **d3.js**) showing how many practices were completed per day over the displayed period.
 
 ### Data
 
-- One bar per day, covering **Monday through Sunday** of the current week.
-- Bar height represents the **number of completed language-learning practices** for that day (both Vocabulary Practice and Inversions count).
+- Bar height represents the **number of completed language-learning practice sessions** for that day. All practice types (Vocabulary, Inversions, …) count equally.
 - Days with no completed practices render a **zero-height bar**; the day label is still shown.
 
-> **⚠️ Spec gap — API endpoint needed.** The app must call an API endpoint to fetch the count of completed practices per day for the current week. The endpoint and response format must be defined and added here before this can be implemented.
+### API
+
+The data comes from `tome-ms-language`. Two endpoint variants are available — the frontend may use either one depending on the desired display mode (see below):
+
+#### Variant A — ISO Week (Monday–Sunday)
+
+```
+GET /tomelang/sessions/stats/weekly?from=YYYYMMDD
+```
+
+- `from`: the **Monday** of the week to display, in `YYYYMMDD` format.
+- Always returns **exactly 7 entries**, one per day Mon–Sun.
+
+**Frontend week calculation:**
+
+```ts
+const today = new Date();
+const day = today.getDay(); // 0 = Sunday
+const monday = new Date(today);
+monday.setDate(today.getDate() - ((day + 6) % 7));
+const from = `${monday.getFullYear()}${String(monday.getMonth()+1).padStart(2,'0')}${String(monday.getDate()).padStart(2,'0')}`;
+```
+
+#### Variant B — Rolling Window (last N days, inclusive today)
+
+```
+GET /tomelang/sessions/stats/rolling?days=7
+```
+
+- `days` (optional, default `7`): number of calendar days to include, ending today (UTC).
+- Always returns **exactly `days` entries**, ordered oldest → newest, with the last entry always being today.
+
+---
+
+Both variants share the same response shape:
+
+```json
+{
+  "days": [
+    { "date": "20260428", "count": 2 },
+    { "date": "20260429", "count": 0 },
+    { "date": "20260430", "count": 1 },
+    { "date": "20260501", "count": 0 },
+    { "date": "20260502", "count": 3 },
+    { "date": "20260503", "count": 0 },
+    { "date": "20260504", "count": 0 }
+  ]
+}
+```
+
+- `date`: `YYYYMMDD` string.
+- `count`: integer ≥ 0; `0` for days with no completed sessions.
+
+### Frontend API client
+
+Add to `api/TomeLanguageAPI.ts`:
+
+```ts
+async getWeeklyStats(from: string): Promise<{ days: Array<{ date: string; count: number }> }> {
+  return (await new TotoAPI().fetch('tome-ms-language', `/tomelang/sessions/stats/weekly?from=${from}`)).json();
+}
+
+async getRollingStats(days = 7): Promise<{ days: Array<{ date: string; count: number }> }> {
+  return (await new TotoAPI().fetch('tome-ms-language', `/tomelang/sessions/stats/rolling?days=${days}`)).json();
+}
+```
+
+### Component
+
+A dedicated `LanguageLearningWeeklyStats` component (e.g. `components/LanguageLearningWeeklyStats.tsx`) should:
+- Accept the weekly data as props (`days: Array<{ date: string; count: number }>`) so it is testable in isolation.
+- Wrap all d3 logic inside a `useEffect` with an SVG ref.
+- Show a loading state while the API call is in flight.
+- Show a graceful empty/error state if the API call fails — **no crash**.
 
 ### Visual style
 
 - **Bars**: filled with the app's primary dark-teal colour (`var(--primary)`, `#155e75`).
 - **X-axis labels**: 3-letter day abbreviations (Mon, Tue, Wed, Thu, Fri, Sat, Sun), displayed below each bar.
 - **Y-axis**: dynamic scale based on the maximum daily count; no axis line or tick labels — the graph is intentionally minimal.
-- **Animation**: bars animate vertically from zero height to their final height when the component mounts.
+- **Animation**: bars animate vertically from zero height to their final height when the component mounts, using a d3 transition:
+
+  ```ts
+  bars.transition().duration(600).ease(d3.easeCubicOut)
+    .attr('y', d => yScale(d.count))
+    .attr('height', d => height - yScale(d.count));
+  ```
+
 - **No border, no grid lines**.
 


### PR DESCRIPTION
## Summary

Implements issue #198 — adds a d3 bar chart to the Language Learning home page showing the number of completed practice sessions per day over the last 7 days (rolling window).

## Changes

### `api/TomeLanguageAPI.ts`
- Added `getRollingStats(days = 7)` calling `GET /tomelang/sessions/stats/rolling?days=N`

### `components/graph/LanguageLearningWeeklyStats.tsx`
- New component accepting `{ days: DayStat[] }` props
- Responsive width via `ResizeObserver`
- d3 bar chart with animated bars (600ms `easeCubicOut`)
- Day labels using `moment(date, 'YYYYMMDD').format('ddd')`
- Three states: `null` = loading, `[]` = error/empty, populated = render chart

### `app/language-learning/page.tsx`
- Added `rollingStats` state (null / DayStat[] / [])
- `useEffect` calls `getRollingStats(7)`, shows loading text while pending
- Renders `<LanguageLearningWeeklyStats>` in the learning stats section

## Depends on
Backend endpoints in `tome-ms-language` PR #14 (`GET /sessions/stats/rolling`).

Closes #198