### PR TITLE
Vocabulary pagination with infinite scroll

### DIFF
--- a/api/TomeLanguageAPI.ts
+++ b/api/TomeLanguageAPI.ts
@@ -10,6 +10,15 @@ export class TomeLanguageAPI {
     }
 
     /**
+     * Fetches a paginated page of vocabulary with per-word practice statistics.
+     * Words are sorted server-side by failure ratio descending (hardest first);
+     * words with no stats appear at the end.
+     */
+    async getVocabularyWithStats(language: string, page: number, pageSize: number): Promise<GetVocabularyWithStatsResponse> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}/with-stats?page=${page}&pageSize=${pageSize}`)).json();
+    }
+
+    /**
      * Fetches the sentences for the specified language
      */
     async getSentences(language: string): Promise<GetSentencesResponse> {
@@ -34,9 +43,31 @@ export interface Word {
     knowledgeSource: string;
 }
 
+export interface WordWithStats {
+    id: string;
+    english: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    stats: {
+        failureRatio: number;
+        totalAttempts: number;
+        totalFailures: number;
+        lastPracticed: string;
+    } | null;
+}
+
 export interface GetVocabularyResponse {
     language: string;
     words: Word[];
+}
+
+export interface GetVocabularyWithStatsResponse {
+    language: string;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    words: WordWithStats[];
 }
 
 export interface Sentence {

--- a/app/language-learning/vocabulary/page.tsx
+++ b/app/language-learning/vocabulary/page.tsx
@@ -1,21 +1,31 @@
 'use client'
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useHeader } from "@/context/HeaderContext";
-import { TomeLanguageAPI, Word } from "@/api/TomeLanguageAPI";
+import { TomeLanguageAPI, WordWithStats } from "@/api/TomeLanguageAPI";
 import { Input } from "@/components/ui/input";
 import { VocabularyListSkeleton } from "@/app/components/LanguageLearningListSkeletons";
+
+const PAGE_SIZE = 100;
 
 export default function VocabularyPage() {
 
     const router = useRouter();
     const { setConfig } = useHeader();
 
-    const [words, setWords] = useState<Word[]>([]);
+    const [words, setWords] = useState<WordWithStats[]>([]);
+    const [currentPage, setCurrentPage] = useState(0);
+    const [totalCount, setTotalCount] = useState(0);
     const [searchQuery, setSearchQuery] = useState("");
     const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const sentinelRef = useRef<HTMLDivElement | null>(null);
+    const observerRef = useRef<IntersectionObserver | null>(null);
+
+    const hasMore = words.length < totalCount;
 
     useEffect(() => {
         setConfig({
@@ -27,38 +37,67 @@ export default function VocabularyPage() {
         });
     }, [setConfig, router]);
 
-    const loadVocabulary = async () => {
-        setIsLoading(true);
-        setError(null);
+    const loadPage = useCallback(async (page: number) => {
         try {
-            const response = await new TomeLanguageAPI().getVocabulary('danish');
-            // Sort alphabetically by Danish word (translation)
-            const sortedWords = response.words.sort((a, b) =>
-                a.translation.localeCompare(b.translation, 'da')
-            );
-            setWords(sortedWords);
+            const response = await new TomeLanguageAPI().getVocabularyWithStats('danish', page, PAGE_SIZE);
+            setTotalCount(response.totalCount);
+            setWords(prev => page === 1 ? response.words : [...prev, ...response.words]);
+            setCurrentPage(page);
         } catch (err) {
             console.error('Error loading vocabulary:', err);
             setError('Failed to load vocabulary. Please try again.');
-        } finally {
-            setIsLoading(false);
         }
-    };
-
-    useEffect(() => {
-        loadVocabulary();
     }, []);
 
-    // Client-side filtering
+    // Initial load
+    useEffect(() => {
+        const initialLoad = async () => {
+            setIsLoading(true);
+            setError(null);
+            await loadPage(1);
+            setIsLoading(false);
+        };
+        initialLoad();
+    }, [loadPage]);
+
+    // Infinite scroll: watch sentinel
+    useEffect(() => {
+        if (!sentinelRef.current || isLoading) return;
+
+        observerRef.current?.disconnect();
+
+        if (!hasMore) return;
+
+        observerRef.current = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && !isLoadingMore) {
+                    const nextPage = currentPage + 1;
+                    setIsLoadingMore(true);
+                    loadPage(nextPage).finally(() => setIsLoadingMore(false));
+                }
+            },
+            { rootMargin: '100px' }
+        );
+
+        observerRef.current.observe(sentinelRef.current);
+
+        return () => observerRef.current?.disconnect();
+    }, [hasMore, isLoading, isLoadingMore, currentPage, loadPage]);
+
     const filteredWords = useMemo(() => {
         if (!searchQuery.trim()) return words;
-
         const query = searchQuery.toLowerCase();
         return words.filter(word =>
             word.translation.toLowerCase().includes(query) ||
             word.english.toLowerCase().includes(query)
         );
     }, [words, searchQuery]);
+
+    const retryLoad = () => {
+        setError(null);
+        setIsLoading(true);
+        loadPage(1).finally(() => setIsLoading(false));
+    };
 
     return (
         <div className="flex flex-1 flex-col items-stretch justify-start">
@@ -77,15 +116,13 @@ export default function VocabularyPage() {
 
                 {/* Word List */}
                 <div className="flex-1 overflow-y-auto px-4 pl-8 mt-4">
-                    {isLoading && (
-                        <VocabularyListSkeleton rows={10} />
-                    )}
+                    {isLoading && <VocabularyListSkeleton rows={10} />}
 
                     {error && (
                         <div className="flex flex-col items-center justify-center py-8">
                             <p className="text-cyan-900 mb-4">{error}</p>
                             <button
-                                onClick={loadVocabulary}
+                                onClick={retryLoad}
                                 className="px-4 py-2 bg-primary text-primary-foreground rounded-md"
                             >
                                 Retry
@@ -112,13 +149,19 @@ export default function VocabularyPage() {
                             ))}
                         </div>
                     )}
+
+                    {/* Shimmer while loading next page */}
+                    {isLoadingMore && <VocabularyListSkeleton rows={5} />}
+
+                    {/* Sentinel for IntersectionObserver */}
+                    <div ref={sentinelRef} className="h-1" />
                 </div>
             </div>
         </div>
     );
 }
 
-function WordItem({ word }: { word: Word }) {
+function WordItem({ word }: { word: WordWithStats }) {
     return (
         <div className="">
             <div className="text-grey-900 font-bold text-lg">

--- a/docs/specs/language-learning/vocabulary-management.md
+++ b/docs/specs/language-learning/vocabulary-management.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Vocabulary Management page allows the user to view and search their full vocabulary for a given language. It provides a read-only browsable list of all words the user is learning, with client-side search functionality.
+The Vocabulary Management page allows the user to view and search their full vocabulary for a given language. It provides a read-only browsable list of words the user is learning, loaded progressively via **infinite scroll pagination**, with client-side search functionality over loaded words.
 
 The target language currently supported is **Danish**.
 
@@ -34,10 +34,10 @@ The page consists of two main sections:
 | **Placeholder text** | "Search words..." |
 | **Search scope** | Searches both the Danish word and the English translation |
 | **Search method** | Case-insensitive substring match |
-| **Execution** | Client-side filtering only; no API call on search |
+| **Execution** | Client-side filtering over currently-loaded words; no API call on search |
 | **Debounce** | Optional; if implemented, debounce should be ≤300ms |
 
-As the user types, the word list filters in real-time to show only words where either the Danish translation or the English word contains the search string.
+As the user types, the word list filters in real-time to show only loaded words where either the Danish translation or the English word contains the search string.
 
 ---
 
@@ -45,7 +45,22 @@ As the user types, the word list filters in real-time to show only words where e
 
 ### Data Source
 
-The word list is fetched from the **Tome Language API** on page load. The API client class should be implemented in the `/api` folder following the existing pattern (e.g. `TomeLanguageAPI.ts`).
+Words are loaded from the **Tome Language API** using the paginated `with-stats` endpoint:
+
+```
+GET /vocabulary/:language/with-stats?page=<n>&pageSize=100
+```
+
+The API client method `getVocabularyWithStats(language, page, pageSize)` is defined in `TomeLanguageAPI.ts`.
+
+- **Page 1** is fetched on mount.
+- **Subsequent pages** are fetched via infinite scroll (see [Pagination / Infinite Scroll](#pagination--infinite-scroll)).
+- Response shape: `{ language, page, pageSize, totalCount, words: WordWithStats[] }`
+- Words include a `stats` field (practice statistics) which is **not displayed** in the current implementation.
+
+### Sort Order
+
+The server returns words sorted by **failure ratio descending** (hardest words first). Words with no practice history appear at the end. The client does **not** re-sort the list.
 
 ### Display
 
@@ -55,8 +70,6 @@ Each list item displays:
 |---------|-------------|
 | **Danish word** | The target-language translation, displayed prominently |
 | **English word** | The source-language word, displayed as secondary text below or beside the Danish word |
-
-The list should be sorted **alphabetically by Danish word** (ascending).
 
 ### Visual Style
 
@@ -68,13 +81,13 @@ The list should be sorted **alphabetically by Danish word** (ascending).
 
 ### Loading State
 
-While the vocabulary is being fetched, the page displays **skeleton placeholder items**:
+**Initial load (page 1):**
+- The full `VocabularyListSkeleton` (10 rows) is shown while page 1 is fetching.
+- The search bar is visible but disabled.
 
-- Show 3–5 placeholder list items in the same layout as real vocabulary items
-- Each placeholder contains rectangular shapes where the Danish word and English translation would appear
-- The placeholder text displays "Loading"
-- A **horizontal gradient animation** sweeps across the placeholders from left to right, giving a shimmer effect to indicate loading activity
-- The search bar is visible but disabled during loading
+**Subsequent pages (infinite scroll):**
+- A smaller `VocabularyListSkeleton` (5 rows) is rendered **below** the already-loaded words while the next page loads.
+- The search bar remains enabled.
 
 ### Empty States
 
@@ -85,13 +98,35 @@ While the vocabulary is being fetched, the page displays **skeleton placeholder 
 
 ---
 
+## Pagination / Infinite Scroll
+
+The list uses **infinite scroll** to progressively load vocabulary pages.
+
+### Mechanism
+
+An `IntersectionObserver` watches a sentinel `<div>` placed at the bottom of the word list. When the sentinel enters the viewport:
+
+1. If `hasMore` is `true` and `isLoadingMore` is `false`, fetch `currentPage + 1`.
+2. Append the returned words to the existing list.
+3. Update `currentPage` and compare `words.length` to `totalCount` to determine `hasMore`.
+
+When `hasMore` becomes `false`, the observer is disconnected.
+
+The observer is cleaned up in the `useEffect` return function.
+
+### Page Size
+
+100 words per page (matches backend default).
+
+---
+
 ## Interactions
 
 | Interaction | Behaviour |
 |-------------|-----------|
 | **Tap on list item** | No action (future: may open word detail view) |
-| **Scroll** | Standard vertical scrolling; search bar remains fixed |
-| **Pull to refresh** | Not required for initial implementation |
+| **Scroll** | Standard vertical scrolling; search bar remains fixed; triggers next page load at bottom |
+| **Pull to refresh** | Not required |
 
 ---
 
@@ -99,13 +134,19 @@ While the vocabulary is being fetched, the page displays **skeleton placeholder 
 
 The page maintains the following local state:
 
-| State | Description |
-|-------|-------------|
-| **words** | Full list of vocabulary words fetched from the API |
-| **searchQuery** | Current value of the search input |
-| **filteredWords** | Derived from `words` filtered by `searchQuery` |
-| **isLoading** | Boolean indicating if the initial fetch is in progress |
-| **error** | Error state if the API call fails |
+| State | Type | Description |
+|-------|------|-------------|
+| **words** | `WordWithStats[]` | Accumulated list of all loaded words |
+| **currentPage** | `number` | Last page number successfully fetched |
+| **totalCount** | `number` | Total number of words server-side |
+| **searchQuery** | `string` | Current value of the search input |
+| **isLoading** | `boolean` | True while fetching page 1 |
+| **isLoadingMore** | `boolean` | True while fetching any page > 1 |
+| **error** | `string \| null` | Error state if the API call fails |
+
+`hasMore` is derived: `words.length < totalCount`.
+
+`filteredWords` is derived: `words` filtered by `searchQuery`.
 
 ---
 
@@ -121,7 +162,8 @@ If the vocabulary API call fails:
 ## Out of Scope
 
 - Adding, editing, or deleting words from this page
-- Server-side search or pagination
+- Server-side search
+- Displaying word practice statistics (`failureRatio`, `totalAttempts`, etc.)
 - Filtering by knowledge source or date
 - Word detail view
 - Audio pronunciation


### PR DESCRIPTION
## Summary

Implements infinite-scroll pagination on the Vocabulary page, using the paginated `with-stats` endpoint.

## Changes

### `api/TomeLanguageAPI.ts`
- Added `getVocabularyWithStats(language, page, pageSize)` method
- Added `WordWithStats` interface (includes optional `stats` field for practice statistics)
- Added `GetVocabularyWithStatsResponse` interface (`page`, `pageSize`, `totalCount`, `words`)

### `app/language-learning/vocabulary/page.tsx`
- Replaced `getVocabulary` with `getVocabularyWithStats` (paginated, 100 words/page)
- Added `IntersectionObserver` on a bottom sentinel `div` to trigger next-page loads
- Added `isLoadingMore` state; renders `VocabularyListSkeleton` (5 rows) below loaded words while fetching
- Removed client-side alphabetical sort (server now sorts by failure ratio descending)
- Search remains client-side, filtering over all currently-loaded words

### `docs/specs/language-learning/vocabulary-management.md`
- Updated spec to reflect pagination, new sort order, and loading states

## Closes

Closes #245
Closes #246
Closes #247