### PR TITLE
feat: Vocabulary & Sentences — Always-On Difficulty Signal

### DIFF
--- a/api/TomeLanguageAPI.ts
+++ b/api/TomeLanguageAPI.ts
@@ -11,11 +11,18 @@ export class TomeLanguageAPI {
 
     /**
      * Fetches a paginated page of vocabulary with per-word practice statistics.
-     * Words are sorted server-side by failure ratio descending (hardest first);
-     * words with no stats appear at the end.
+     * Always sorted by difficulty descending (hardest first); words with no stats appear at the end.
      */
     async getVocabularyWithStats(language: string, page: number, pageSize: number): Promise<GetVocabularyWithStatsResponse> {
-        return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}/with-stats?page=${page}&pageSize=${pageSize}`)).json();
+        return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}/with-stats?page=${page}&pageSize=${pageSize}&sortBy=difficulty&sortDir=desc`)).json();
+    }
+
+    /**
+     * Fetches a paginated page of sentences with per-sentence practice statistics.
+     * Always sorted by difficulty descending (hardest first); sentences with no stats appear at the end.
+     */
+    async getSentencesWithStats(language: string, page: number, pageSize: number): Promise<GetSentencesWithStatsResponse> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/sentences/${language}/with-stats?page=${page}&pageSize=${pageSize}&sortBy=difficulty&sortDir=desc`)).json();
     }
 
     /**
@@ -76,6 +83,28 @@ export interface Sentence {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+}
+
+export interface GetSentencesWithStatsResponse {
+    language: string;
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    sentences: SentenceWithStats[];
+}
+
+export interface SentenceWithStats {
+    id: string;
+    sentence: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    stats: {
+        failureRatio: number;
+        totalAttempts: number;
+        totalFailures: number;
+        lastPracticed: string;
+    } | null;
 }
 
 export interface GetSentencesResponse {

--- a/app/components/DifficultySignal.tsx
+++ b/app/components/DifficultySignal.tsx
@@ -1,0 +1,23 @@
+import { MaskedSvgIcon } from "toto-react";
+
+interface DifficultySignalProps {
+    failureRatio: number | null;
+}
+
+function getSignalIcon(failureRatio: number | null): { src: string; alt: string } {
+    if (failureRatio === null || failureRatio < 0.25) {
+        return { src: "/images/signal-weak.svg", alt: "Low difficulty" };
+    }
+    if (failureRatio < 0.5) {
+        return { src: "/images/signal-fair.svg", alt: "Fair difficulty" };
+    }
+    if (failureRatio < 0.75) {
+        return { src: "/images/signal-good.svg", alt: "Good difficulty" };
+    }
+    return { src: "/images/signal.svg", alt: "High difficulty" };
+}
+
+export function DifficultySignal({ failureRatio }: DifficultySignalProps) {
+    const icon = getSignalIcon(failureRatio);
+    return <MaskedSvgIcon src={icon.src} alt={icon.alt} />;
+}

--- a/app/language-learning/sentences/page.tsx
+++ b/app/language-learning/sentences/page.tsx
@@ -1,19 +1,31 @@
 'use client'
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useHeader } from "@/context/HeaderContext";
 import { MaskedSvgIcon, RoundButton } from "toto-react";
-import { TomeLanguageAPI, Sentence } from "@/api/TomeLanguageAPI";
+import { TomeLanguageAPI, SentenceWithStats } from "@/api/TomeLanguageAPI";
 import { SentencesListSkeleton } from "@/app/components/LanguageLearningListSkeletons";
+import { DifficultySignal } from "@/app/components/DifficultySignal";
+
+const PAGE_SIZE = 100;
 
 export default function SentencesPage() {
 
     const router = useRouter();
     const { setConfig } = useHeader();
 
-    const [sentences, setSentences] = useState<Sentence[] | null>(null);
+    const [sentences, setSentences] = useState<SentenceWithStats[]>([]);
+    const [currentPage, setCurrentPage] = useState(0);
+    const [totalCount, setTotalCount] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const sentinelRef = useRef<HTMLDivElement | null>(null);
+    const observerRef = useRef<IntersectionObserver | null>(null);
+
+    const hasMore = sentences.length < totalCount;
 
     useEffect(() => {
         setConfig({
@@ -25,21 +37,58 @@ export default function SentencesPage() {
         });
     }, [setConfig, router]);
 
-    const loadSentences = () => {
-        setError(null);
-        setSentences(null);
-        new TomeLanguageAPI()
-            .getSentences('danish')
-            .then((res) => setSentences(res.sentences))
-            .catch(() => {
-                setError('Could not load sentences. Please try again.');
-                setSentences([]);
-            });
-    };
-
-    useEffect(() => {
-        loadSentences();
+    const loadPage = useCallback(async (page: number) => {
+        try {
+            const response = await new TomeLanguageAPI().getSentencesWithStats('danish', page, PAGE_SIZE);
+            setTotalCount(response.totalCount);
+            setSentences(prev => page === 1 ? response.sentences : [...prev, ...response.sentences]);
+            setCurrentPage(page);
+        } catch (err) {
+            console.error('Error loading sentences:', err);
+            setError('Could not load sentences. Please try again.');
+        }
     }, []);
+
+    // Initial load
+    useEffect(() => {
+        const initialLoad = async () => {
+            setIsLoading(true);
+            setError(null);
+            await loadPage(1);
+            setIsLoading(false);
+        };
+        initialLoad();
+    }, [loadPage]);
+
+    // Infinite scroll: watch sentinel
+    useEffect(() => {
+        if (!sentinelRef.current || isLoading) return;
+
+        observerRef.current?.disconnect();
+
+        if (!hasMore) return;
+
+        observerRef.current = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && !isLoadingMore) {
+                    const nextPage = currentPage + 1;
+                    setIsLoadingMore(true);
+                    loadPage(nextPage).finally(() => setIsLoadingMore(false));
+                }
+            },
+            { rootMargin: '100px' }
+        );
+
+        observerRef.current.observe(sentinelRef.current);
+
+        return () => observerRef.current?.disconnect();
+    }, [hasMore, isLoading, isLoadingMore, currentPage, loadPage]);
+
+    const retryLoad = () => {
+        setError(null);
+        setIsLoading(true);
+        loadPage(1).finally(() => setIsLoading(false));
+    };
 
     return (
         <div className="flex flex-1 flex-col items-stretch">
@@ -55,26 +104,24 @@ export default function SentencesPage() {
 
             <div className="flex flex-col px-4 pt-4 gap-4 flex-1 items-stretch overflow-y-auto min-h-0">
 
+                {/* Loading state */}
+                {isLoading && <SentencesListSkeleton rows={7} />}
+
                 {/* Error state */}
                 {error && (
                     <div className="flex flex-col items-center gap-3 mt-8">
                         <p className="text-sm text-destructive text-center">{error}</p>
                         <button
-                            className="text-sm text-primary-foreground underline"
-                            onClick={loadSentences}
+                            className="text-sm text-primary underline"
+                            onClick={retryLoad}
                         >
                             Retry
                         </button>
                     </div>
                 )}
 
-                {/* Loading state */}
-                {sentences === null && !error && (
-                    <SentencesListSkeleton rows={7} />
-                )}
-
                 {/* Empty state */}
-                {sentences !== null && sentences.length === 0 && (
+                {!isLoading && !error && sentences.length === 0 && (
                     <div className="flex flex-col items-center gap-3 mt-8">
                         <p className="text-sm text-muted-foreground text-center">
                             No sentences yet. Tap the wand above to generate some.
@@ -83,29 +130,41 @@ export default function SentencesPage() {
                 )}
 
                 {/* Sentences list */}
-                {sentences !== null && sentences.length > 0 && (
+                {!isLoading && !error && sentences.length > 0 && (
                     <div className="flex flex-col mt-4">
                         {sentences.map((sentence) => (
                             <SentenceRow key={sentence.id} sentence={sentence} />
                         ))}
                     </div>
                 )}
+
+                {/* Shimmer while loading next page */}
+                {isLoadingMore && <SentencesListSkeleton rows={5} />}
+
+                {/* Sentinel for IntersectionObserver */}
+                <div ref={sentinelRef} className="h-1" />
             </div>
         </div>
     );
 }
 
-function SentenceRow({ sentence }: { sentence: Sentence }) {
+function SentenceRow({ sentence }: { sentence: SentenceWithStats }) {
     return (
-        <div className="border-b border-cyan-600 py-2 flex flex-row">
-            <div className="mr-2">
-                {sentence.knowledgeSource == 'tome-agent' && <MaskedSvgIcon src="/images/agent.svg" alt="Tome Agent" />}
-                {sentence.knowledgeSource != 'tome-agent' && <MaskedSvgIcon src="/images/book.svg" alt="Golden Source"/>}
+        <div className="border-b border-cyan-600 py-2 flex flex-row items-center justify-between">
+            <div className="flex flex-row items-center gap-2 flex-1 min-w-0 mr-3">
+                <div className="shrink-0">
+                    {sentence.knowledgeSource == 'tome-agent' && <MaskedSvgIcon src="/images/agent.svg" alt="Tome Agent" />}
+                    {sentence.knowledgeSource != 'tome-agent' && <MaskedSvgIcon src="/images/book.svg" alt="Golden Source" />}
+                </div>
+                <div className="min-w-0">
+                    <div className="text-sm font-medium text-grey-900">{sentence.sentence}</div>
+                    <div className="text-xs text-muted-foreground mt-1">{sentence.translation}</div>
+                </div>
             </div>
-            <div>
-                <div className="text-sm font-medium text-grey-900">{sentence.sentence}</div>
-                <div className="text-xs text-muted-foreground mt-1">{sentence.translation}</div>
+            <div className="shrink-0">
+                <DifficultySignal failureRatio={sentence.stats?.failureRatio ?? null} />
             </div>
         </div>
     );
 }
+

--- a/app/language-learning/vocabulary/page.tsx
+++ b/app/language-learning/vocabulary/page.tsx
@@ -6,6 +6,7 @@ import { useHeader } from "@/context/HeaderContext";
 import { TomeLanguageAPI, WordWithStats } from "@/api/TomeLanguageAPI";
 import { Input } from "@/components/ui/input";
 import { VocabularyListSkeleton } from "@/app/components/LanguageLearningListSkeletons";
+import { DifficultySignal } from "@/app/components/DifficultySignal";
 
 const PAGE_SIZE = 100;
 
@@ -163,13 +164,16 @@ export default function VocabularyPage() {
 
 function WordItem({ word }: { word: WordWithStats }) {
     return (
-        <div className="">
-            <div className="text-grey-900 font-bold text-lg">
-                {word.translation}
+        <div className="flex items-center justify-between">
+            <div>
+                <div className="text-grey-900 font-bold text-lg">
+                    {word.translation}
+                </div>
+                <div className="text-muted-foreground text-sm">
+                    {word.english}
+                </div>
             </div>
-            <div className="text-muted-foreground text-sm ">
-                {word.english}
-            </div>
+            <DifficultySignal failureRatio={word.stats?.failureRatio ?? null} />
         </div>
     );
 }

--- a/docs/specs/language-learning/sentences-difficulty-signal.md
+++ b/docs/specs/language-learning/sentences-difficulty-signal.md
@@ -1,0 +1,84 @@
+# Spec: Sentences Page — Always-On Difficulty Signal
+
+**GitHub Issue:** [#251 — Sentences Page: Always-On Difficulty Signal](https://github.com/nicolasances/tome/issues/251)
+**Parent Feature:** [#249 — Vocabulary & Sentences — Always-On Difficulty Signal](https://github.com/nicolasances/tome/issues/249)
+**Depends on:** [#250 — Vocabulary Page: Always-On Difficulty Signal](https://github.com/nicolasances/tome/issues/250) (for `DifficultySignal` component)
+
+---
+
+## Objective
+
+Apply the same always-on difficulty signal pattern from the Vocabulary page to the Sentences page. Sentences always load hardest first and each row shows a difficulty signal icon.
+
+This requires migrating the Sentences page away from the basic `getSentences` endpoint (which returns no stats) to the `getSentencesWithStats` endpoint (which returns `failureRatio` per sentence and supports difficulty sorting). The page also gains infinite scroll pagination as a side effect of using the paginated endpoint.
+
+---
+
+## Core Logic
+
+### 1. API Layer — `getSentencesWithStats`
+
+A new method `getSentencesWithStats()` is added to `TomeLanguageAPI`, and a new `SentenceWithStats` interface is exported.
+
+```ts
+async getSentencesWithStats(
+  language: string,
+  page: number,
+  pageSize: number
+): Promise<GetSentencesWithStatsResponse>
+```
+
+The method always appends `&sortBy=difficulty&sortDir=desc` to the query string. It calls the existing backend endpoint: `GET /sentences/:language/with-stats`.
+
+**New types:**
+
+```ts
+export interface SentenceWithStats {
+  id: string;
+  sentence: string;
+  translation: string;
+  createdAt: string;
+  knowledgeSource: string;
+  stats: {
+    failureRatio: number;
+    totalAttempts: number;
+    totalFailures: number;
+    lastPracticed: string;
+  } | null;
+}
+
+export interface GetSentencesWithStatsResponse {
+  language: string;
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  sentences: SentenceWithStats[];
+}
+```
+
+### 2. Sentences Page Migration
+
+The Sentences page is rewritten to match the Vocabulary page pattern:
+
+- State: `sentences: SentenceWithStats[]`, `currentPage`, `totalCount`, `isLoading`, `isLoadingMore`, `error`
+- `loadPage(page)` calls `getSentencesWithStats('danish', page, PAGE_SIZE)` and appends results
+- Infinite scroll via `IntersectionObserver` on a sentinel `<div>` at the bottom of the list
+- `PAGE_SIZE = 100` (consistent with Vocabulary)
+
+The old `getSentences` call is removed from the page.
+
+### 3. SentenceRow Update
+
+The `SentenceRow` component is updated to include the `DifficultySignal` component (from issue #250) on the far right of the row.
+
+The `sentence` prop type changes from `Sentence` to `SentenceWithStats`. The `failureRatio` is read from `sentence.stats?.failureRatio ?? null`.
+
+---
+
+## Out of Scope
+
+- Search bar on the Sentences page
+- Sort toggle / user-controlled sort direction
+- Filter by difficulty tier
+- Any backend changes
+- Removing the existing `getSentences` method from `TomeLanguageAPI` (it may still be used elsewhere)

--- a/docs/specs/language-learning/vocabulary-difficulty-signal.md
+++ b/docs/specs/language-learning/vocabulary-difficulty-signal.md
@@ -1,0 +1,55 @@
+# Spec: Vocabulary Page — Always-On Difficulty Signal
+
+**GitHub Issue:** [#250 — Vocabulary Page: Always-On Difficulty Signal](https://github.com/nicolasances/tome/issues/250)
+**Parent Feature:** [#249 — Vocabulary & Sentences — Always-On Difficulty Signal](https://github.com/nicolasances/tome/issues/249)
+
+---
+
+## Objective
+
+Help a learner immediately see where they're struggling on the Vocabulary page without any extra interaction.
+
+The list always loads hardest words first (`sortBy=difficulty&sortDir=desc`), and each word row shows a small difficulty signal icon on the far right derived from the word's `failureRatio`. No sort toggle — the ordering is fixed and always optimised for the learner's weakest words.
+
+---
+
+## Core Logic
+
+### 1. Always-Sort by Difficulty
+
+The `getVocabularyWithStats()` call in `TomeLanguageAPI` is updated to always append `&sortBy=difficulty&sortDir=desc` to the query string.
+
+No UI control is exposed to change the sort order.
+
+### 2. Difficulty Signal Component
+
+A new reusable React component `DifficultySignal` is created at `app/components/DifficultySignal.tsx`.
+
+It accepts a single prop: `failureRatio: number | null`.
+
+Mapping from `failureRatio` to SVG asset:
+
+| `failureRatio` value   | Icon file          |
+|------------------------|--------------------|
+| `null` (no practice)   | `signal-weak.svg`  |
+| `< 0.25`               | `signal-weak.svg`  |
+| `>= 0.25` and `< 0.5`  | `signal-fair.svg`  |
+| `>= 0.5` and `< 0.75`  | `signal-good.svg`  |
+| `>= 0.75`              | `signal.svg`       |
+
+The SVG assets already exist in `/public/images/`. The component uses a standard `<img>` tag (or `next/image`) to render the icon.
+
+The icon is sized consistently with other row icons in the app (e.g. 20×20 px).
+
+### 3. WordItem Row Update
+
+The `WordItem` component in the Vocabulary page is updated to include `DifficultySignal` on the far right of the row. The row uses a flex layout with the word content on the left and the icon on the right (`justify-between`).
+
+---
+
+## Out of Scope
+
+- Sort toggle (asc/desc/off) — hardest-first is always the right view for a learner
+- Filter by difficulty tier
+- Any backend changes (the API already supports the sort params)
+- Alphabetical sort option


### PR DESCRIPTION
## Summary

Implements the always-on difficulty signal on the Vocabulary and Sentences pages.

Closes #250, Closes #251
Parent feature: #249

## Changes

### API Layer (`api/TomeLanguageAPI.ts`)
- `getVocabularyWithStats` now always passes `sortBy=difficulty&sortDir=desc`
- New `getSentencesWithStats()` method + `SentenceWithStats` / `GetSentencesWithStatsResponse` types

### New Component (`app/components/DifficultySignal.tsx`)
- Reusable `DifficultySignal` component mapping `failureRatio` to the correct signal SVG:
  - `null` or `< 0.25` → `signal-weak.svg`
  - `0.25–0.5` → `signal-fair.svg`
  - `0.5–0.75` → `signal-good.svg`
  - `≥ 0.75` → `signal.svg`

### Vocabulary Page
- Words always load hardest first
- Each `WordItem` row shows `DifficultySignal` on the far right

### Sentences Page
- Migrated from basic `getSentences` → `getSentencesWithStats` (with stats + pagination)
- Added infinite scroll (IntersectionObserver, PAGE\_SIZE=100) — same pattern as Vocabulary
- Each `SentenceRow` shows `DifficultySignal` on the far right

## Specs
- [vocabulary-difficulty-signal.md](docs/specs/language-learning/vocabulary-difficulty-signal.md)
- [sentences-difficulty-signal.md](docs/specs/language-learning/sentences-difficulty-signal.md)