### PR TITLE
feat: alternative translations (#254, #255, #256, #257, #258)

### DIFF
--- a/api/MockSentencePracticeAPI.ts
+++ b/api/MockSentencePracticeAPI.ts
@@ -4,13 +4,13 @@ import { SentencePracticeSession, SentencePracticeSentence, SentenceSessionSumma
 const ACTIVE_SESSION_KEY = 'sentence-active-session';
 
 const HARDCODED_SENTENCES: Omit<SentencePracticeSentence, 'failedAttempts'>[] = [
-  { id: 's1', sentence: 'Jeg spiser morgenmad hver dag.', translation: 'I eat breakfast every day.' },
-  { id: 's2', sentence: 'Hun læser en interessant bog.', translation: 'She is reading an interesting book.' },
-  { id: 's3', sentence: 'Vi går en tur i parken om eftermiddagen.', translation: 'We take a walk in the park in the afternoon.' },
-  { id: 's4', sentence: 'Han arbejder på et stort projekt.', translation: 'He is working on a big project.' },
-  { id: 's5', sentence: 'De bor i en lille by ved havet.', translation: 'They live in a small town by the sea.' },
-  { id: 's6', sentence: 'Jeg kan godt lide at lytte til musik.', translation: 'I like to listen to music.' },
-  { id: 's7', sentence: 'Børnene leger i haven efter skole.', translation: 'The children play in the garden after school.' },
+  { id: 's1', sentence: 'Jeg spiser morgenmad hver dag.', translation: 'I eat breakfast every day.', alternativeTranslations: [] },
+  { id: 's2', sentence: 'Hun læser en interessant bog.', translation: 'She is reading an interesting book.', alternativeTranslations: [] },
+  { id: 's3', sentence: 'Vi går en tur i parken om eftermiddagen.', translation: 'We take a walk in the park in the afternoon.', alternativeTranslations: [] },
+  { id: 's4', sentence: 'Han arbejder på et stort projekt.', translation: 'He is working on a big project.', alternativeTranslations: [] },
+  { id: 's5', sentence: 'De bor i en lille by ved havet.', translation: 'They live in a small town by the sea.', alternativeTranslations: [] },
+  { id: 's6', sentence: 'Jeg kan godt lide at lytte til musik.', translation: 'I like to listen to music.', alternativeTranslations: [] },
+  { id: 's7', sentence: 'Børnene leger i haven efter skole.', translation: 'The children play in the garden after school.', alternativeTranslations: [] },
 ];
 
 function generateUUID(): string {

--- a/api/MockVocabularyPracticeAPI.ts
+++ b/api/MockVocabularyPracticeAPI.ts
@@ -4,16 +4,16 @@ import { VocabPracticeSession, VocabPracticeWord, SessionSummary } from '@/model
 const ACTIVE_SESSION_KEY = 'vocab-active-session';
 
 const HARDCODED_WORDS: Omit<VocabPracticeWord, 'failedAttempts'>[] = [
-  { id: 'w1',  english: 'dog',      translation: 'hund'     },
-  { id: 'w2',  english: 'cat',      translation: 'kat'      },
-  { id: 'w3',  english: 'house',    translation: 'hus'      },
-  { id: 'w4',  english: 'car',      translation: 'bil'      },
-  { id: 'w5',  english: 'water',    translation: 'vand'     },
-  { id: 'w6',  english: 'book',     translation: 'bog'      },
-  { id: 'w7',  english: 'chair',    translation: 'stol'     },
-  { id: 'w8',  english: 'table',    translation: 'bord'     },
-  { id: 'w9',  english: 'window',   translation: 'vindue'   },
-  { id: 'w10', english: 'door',     translation: 'dør'      },
+  { id: 'w1',  english: 'dog',      translation: 'hund',    alternativeTranslations: [] },
+  { id: 'w2',  english: 'cat',      translation: 'kat',     alternativeTranslations: [] },
+  { id: 'w3',  english: 'house',    translation: 'hus',     alternativeTranslations: [] },
+  { id: 'w4',  english: 'car',      translation: 'bil',     alternativeTranslations: [] },
+  { id: 'w5',  english: 'water',    translation: 'vand',    alternativeTranslations: [] },
+  { id: 'w6',  english: 'book',     translation: 'bog',     alternativeTranslations: [] },
+  { id: 'w7',  english: 'chair',    translation: 'stol',    alternativeTranslations: [] },
+  { id: 'w8',  english: 'table',    translation: 'bord',    alternativeTranslations: [] },
+  { id: 'w9',  english: 'window',   translation: 'vindue',  alternativeTranslations: [] },
+  { id: 'w10', english: 'door',     translation: 'dør',     alternativeTranslations: [] },
 ];
 
 function generateUUID(): string {

--- a/api/TomeLLMVerifyAPI.ts
+++ b/api/TomeLLMVerifyAPI.ts
@@ -1,6 +1,7 @@
 export interface LLMVerifyResult {
     acceptable: boolean;
     explanation: string;
+    correctedTranslation?: string;
 }
 
 export class TomeLLMVerifyAPI {

--- a/api/TomeLanguageAPI.ts
+++ b/api/TomeLanguageAPI.ts
@@ -40,6 +40,30 @@ export class TomeLanguageAPI {
         return (await new TotoAPI().fetch('tome-ms-language', `/sessions/stats/rolling?days=${days}`)).json();
     }
 
+    async getWord(language: string, wordId: string): Promise<WordDetail> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}/words/${wordId}`)).json();
+    }
+
+    async getSentence(language: string, sentenceId: string): Promise<SentenceDetail> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/sentences/${language}/${sentenceId}`)).json();
+    }
+
+    async addWordAlternative(language: string, wordId: string, translation: string): Promise<AlternativeTranslation> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}/words/${wordId}/alternatives`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ translation }) })).json();
+    }
+
+    async removeWordAlternative(language: string, wordId: string, id: string): Promise<void> {
+        await new TotoAPI().fetch('tome-ms-language', `/vocabulary/${language}/words/${wordId}/alternatives/${id}`, { method: 'DELETE' });
+    }
+
+    async addSentenceAlternative(language: string, sentenceId: string, translation: string): Promise<AlternativeTranslation> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/sentences/${language}/${sentenceId}/alternatives`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ translation }) })).json();
+    }
+
+    async removeSentenceAlternative(language: string, sentenceId: string, id: string): Promise<void> {
+        await new TotoAPI().fetch('tome-ms-language', `/sentences/${language}/${sentenceId}/alternatives/${id}`, { method: 'DELETE' });
+    }
+
 }
 
 export interface Word {
@@ -56,6 +80,7 @@ export interface WordWithStats {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
     stats: {
         failureRatio: number;
         totalAttempts: number;
@@ -99,6 +124,7 @@ export interface SentenceWithStats {
     translation: string;
     createdAt: string;
     knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
     stats: {
         failureRatio: number;
         totalAttempts: number;
@@ -110,4 +136,29 @@ export interface SentenceWithStats {
 export interface GetSentencesResponse {
     language: string;
     sentences: Sentence[];
+}
+
+export interface AlternativeTranslation {
+    id: string;
+    translation: string;
+}
+
+export interface WordDetail {
+    id: string;
+    language: string;
+    english: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    alternativeTranslations: AlternativeTranslation[];
+}
+
+export interface SentenceDetail {
+    id: string;
+    language: string;
+    sentence: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    alternativeTranslations: AlternativeTranslation[];
 }

--- a/api/TomeSentencePracticeAPI.ts
+++ b/api/TomeSentencePracticeAPI.ts
@@ -21,6 +21,7 @@ interface BackendSentence {
   sentenceId: string;
   sentence: string;
   translation: string;
+  alternativeTranslations?: Array<{ id: string; translation: string }>;
 }
 
 interface BackendSessionResponse {
@@ -50,6 +51,7 @@ function mapBackendSentences(backendSentences: BackendSentence[]): SentencePract
     sentence: s.sentence,
     translation: s.translation,
     failedAttempts: 0,
+    alternativeTranslations: s.alternativeTranslations ?? [],
   }));
 }
 

--- a/api/TomeVocabularyPracticeAPI.ts
+++ b/api/TomeVocabularyPracticeAPI.ts
@@ -21,6 +21,7 @@ interface BackendWord {
   wordId: string;
   english: string;
   translation: string;
+  alternativeTranslations?: Array<{ id: string; translation: string }>;
 }
 
 interface BackendSessionResponse {
@@ -37,6 +38,7 @@ function mapBackendWords(backendWords: BackendWord[]): VocabPracticeWord[] {
     english: w.english,
     translation: w.translation,
     failedAttempts: 0,
+    alternativeTranslations: w.alternativeTranslations ?? [],
   }));
 }
 

--- a/app/api/llm-verify/route.ts
+++ b/app/api/llm-verify/route.ts
@@ -21,14 +21,15 @@ Reference Danish answer: "${expectedAnswer}"
 Learner's answer: "${userAnswer}"
 Is the learner's answer an acceptable Danish translation of the English sentence?
 A translation is acceptable if it conveys the same meaning correctly, even if phrased slightly differently. Minor word-order differences or synonyms are acceptable; wrong grammar or wrong meaning is not.
-Respond with JSON only: {"acceptable": true or false, "explanation": "<one sentence>"}`;
+When acceptable is true, also return correctedTranslation: the learner's answer with any spelling or grammar mistakes fixed, without changing the meaning or phrasing. If no corrections are needed, return the learner's answer unchanged.
+Respond with JSON only: {"acceptable": true or false, "explanation": "<one sentence>", "correctedTranslation": "<string, only when acceptable is true>"}`;
 }
 
 async function callGemini(
     vertexAI: VertexAI,
     modelName: string,
     prompt: string
-): Promise<{ acceptable: boolean; explanation: string }> {
+): Promise<{ acceptable: boolean; explanation: string; correctedTranslation?: string }> {
     const model = vertexAI.getGenerativeModel({
         model: modelName,
         generationConfig: { responseMimeType: 'application/json' },
@@ -41,7 +42,13 @@ async function callGemini(
     if (typeof parsed.acceptable !== 'boolean' || typeof parsed.explanation !== 'string') {
         throw new Error('Unexpected model response shape');
     }
-    return { acceptable: parsed.acceptable, explanation: parsed.explanation };
+    return {
+        acceptable: parsed.acceptable,
+        explanation: parsed.explanation,
+        ...(parsed.acceptable && typeof parsed.correctedTranslation === 'string'
+            ? { correctedTranslation: parsed.correctedTranslation }
+            : {}),
+    };
 }
 
 export async function POST(request: NextRequest) {

--- a/app/language-learning/sentence-practice/page.tsx
+++ b/app/language-learning/sentence-practice/page.tsx
@@ -175,10 +175,12 @@ export default function SentencePracticePage() {
 
         const userAnswer = answer.trim();
         const normalizedUser = normalizeForComparison(userAnswer);
-        const normalizedExpected = normalizeForComparison(sentence.sentence);
 
-        const tier1 = normalizedUser === normalizedExpected;
-        const tier2 = !tier1 && levenshteinDistance(normalizedUser, normalizedExpected) <= 2;
+        const matchesTier1 = (candidate: string) => normalizedUser === normalizeForComparison(candidate);
+        const matchesTier2 = (candidate: string) => levenshteinDistance(normalizedUser, normalizeForComparison(candidate)) <= 2;
+
+        const tier1 = matchesTier1(sentence.translation) || sentence.alternativeTranslations.some((a) => matchesTier1(a.translation));
+        const tier2 = !tier1 && (matchesTier2(sentence.translation) || sentence.alternativeTranslations.some((a) => matchesTier2(a.translation)));
         const isCorrect = tier1 || tier2;
 
         setResult({ isCorrect, userAnswer });

--- a/app/language-learning/sentence-practice/page.tsx
+++ b/app/language-learning/sentence-practice/page.tsx
@@ -10,6 +10,7 @@ import { TranslationInput } from '@/components/TranslationInput';
 import { PracticeResult } from '@/app/components/PracticeResult';
 import { RoundButton } from 'toto-react';
 import { TomeLLMVerifyAPI, LLMVerifyResult } from '@/api/TomeLLMVerifyAPI';
+import { TomeLanguageAPI } from '@/api/TomeLanguageAPI';
 
 type ResultState = { isCorrect: boolean; userAnswer: string } | null;
 
@@ -266,6 +267,10 @@ export default function SentencePracticePage() {
                     nextFailedAttempts: currentFailedAttempts,
                 };
                 setResult((prev) => prev ? { ...prev, isCorrect: true } : prev);
+
+                // Store AI-corrected alternative — fire-and-forget
+                new TomeLanguageAPI().addSentenceAlternative('danish', sentence.id, verdict.correctedTranslation ?? result.userAnswer)
+                    .catch((e) => console.error('addSentenceAlternative failed:', e));
             }
 
             setLlmResult(verdict);

--- a/app/language-learning/sentences/[sentenceId]/page.tsx
+++ b/app/language-learning/sentences/[sentenceId]/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useHeader } from '@/context/HeaderContext';
+import { TomeLanguageAPI, SentenceDetail, AlternativeTranslation } from '@/api/TomeLanguageAPI';
+import { MaskedSvgIcon } from '@/app/components/MaskedSvgIcon';
+import { RoundButton } from 'toto-react';
+
+export default function SentenceDetailPage() {
+    const router = useRouter();
+    const params = useParams();
+    const sentenceId = params.sentenceId as string;
+    const { setConfig } = useHeader();
+
+    const [sentence, setSentence] = useState<SentenceDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [newAlt, setNewAlt] = useState('');
+    const [adding, setAdding] = useState(false);
+
+    useEffect(() => {
+        setConfig({
+            title: 'Sentence Details',
+            backButton: {
+                enabled: true,
+                onClick: () => router.push('/language-learning/sentences'),
+            },
+        });
+    }, [setConfig, router]);
+
+    const loadSentence = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await new TomeLanguageAPI().getSentence('danish', sentenceId);
+            setSentence(data);
+        } catch (e) {
+            setError((e as Error).message ?? 'Failed to load sentence');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (sentenceId) loadSentence();
+    }, [sentenceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleRemoveAlternative = (alt: AlternativeTranslation) => {
+        if (!sentence) return;
+        // Optimistic remove
+        setSentence((prev) => prev ? { ...prev, alternativeTranslations: prev.alternativeTranslations.filter((a) => a.id !== alt.id) } : prev);
+        new TomeLanguageAPI().removeSentenceAlternative('danish', sentenceId, alt.id)
+            .catch((e) => {
+                console.error('removeSentenceAlternative failed:', e);
+                // Revert on error
+                setSentence((prev) => prev ? { ...prev, alternativeTranslations: [...prev.alternativeTranslations, alt] } : prev);
+            });
+    };
+
+    const handleAddAlternative = async () => {
+        const trimmed = newAlt.trim();
+        if (!trimmed || !sentence || adding) return;
+        setAdding(true);
+        setNewAlt('');
+        try {
+            const created = await new TomeLanguageAPI().addSentenceAlternative('danish', sentenceId, trimmed);
+            setSentence((prev) => prev ? { ...prev, alternativeTranslations: [...prev.alternativeTranslations, created] } : prev);
+        } catch (e) {
+            console.error('addSentenceAlternative failed:', e);
+            setNewAlt(trimmed); // restore on error
+        } finally {
+            setAdding(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex flex-1 items-center justify-center">
+                <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-primary" />
+            </div>
+        );
+    }
+
+    if (error || !sentence) {
+        return (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+                <p className="text-destructive text-center">{error ?? 'Sentence not found'}</p>
+                <button onClick={loadSentence} className="px-4 py-2 rounded-md bg-primary text-primary-foreground">
+                    Retry
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-1 flex-col items-stretch px-6 pt-8 gap-6 overflow-y-auto">
+            {/* Sentence header */}
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                    <MaskedSvgIcon
+                        src={sentence.knowledgeSource === 'tome-agent' ? '/images/agent.svg' : '/images/book.svg'}
+                        alt={sentence.knowledgeSource}
+                        size="w-5 h-5"
+                        color="bg-cyan-800"
+                    />
+                    <span className="text-xs text-muted-foreground uppercase tracking-widest">{sentence.knowledgeSource}</span>
+                </div>
+                <span className="text-2xl font-bold text-foreground">{sentence.sentence}</span>
+                <span className="text-base text-muted-foreground">{sentence.translation}</span>
+            </div>
+
+            {/* Alternatives list */}
+            <div className="flex flex-col gap-2">
+                <span className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Alternative Translations</span>
+                {sentence.alternativeTranslations.length === 0 && (
+                    <p className="text-sm text-muted-foreground">No alternatives yet.</p>
+                )}
+                {sentence.alternativeTranslations.map((alt) => (
+                    <div key={alt.id} className="flex items-center justify-between border border-cyan-600 rounded-md px-4 py-2">
+                        <span className="text-sm text-foreground">{alt.translation}</span>
+                        <button
+                            onClick={() => handleRemoveAlternative(alt)}
+                            className="text-destructive text-xs ml-4 shrink-0"
+                            aria-label="Remove"
+                        >
+                            ✕
+                        </button>
+                    </div>
+                ))}
+            </div>
+
+            {/* Add new alternative */}
+            <div className="flex flex-col gap-3 pb-8">
+                <span className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Add Alternative</span>
+                <div className="flex items-center gap-3">
+                    <input
+                        type="text"
+                        value={newAlt}
+                        onChange={(e) => setNewAlt(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleAddAlternative(); }}
+                        placeholder="Type new translation…"
+                        className="flex-1 border border-cyan-600 rounded-full px-4 py-2 text-sm text-cyan-900 placeholder:text-cyan-700/50 focus:outline-none focus:border-lime-200 bg-transparent"
+                        disabled={adding}
+                    />
+                    <RoundButton
+                        svgIconPath={{ src: '/images/point-right.svg', alt: 'Add', color: 'bg-lime-200' }}
+                        onClick={handleAddAlternative}
+                        type="primary"
+                        loading={adding}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/language-learning/sentences/[sentenceId]/page.tsx
+++ b/app/language-learning/sentences/[sentenceId]/page.tsx
@@ -97,17 +97,23 @@ export default function SentenceDetailPage() {
         <div className="flex flex-1 flex-col items-stretch px-6 pt-8 gap-6 overflow-y-auto">
             {/* Sentence header */}
             <div className="flex flex-col gap-1">
-                <div className="flex items-center gap-2">
+                <div className="flex items-start gap-4">
                     <MaskedSvgIcon
                         src={sentence.knowledgeSource === 'tome-agent' ? '/images/agent.svg' : '/images/book.svg'}
                         alt={sentence.knowledgeSource}
                         size="w-5 h-5"
                         color="bg-cyan-800"
                     />
-                    <span className="text-xs text-muted-foreground uppercase tracking-widest">{sentence.knowledgeSource}</span>
+                    <div className='flex flex-col gap-1'>
+                        <span className="text-xl font-bold text-foreground">{sentence.translation}</span>
+                        <span className="text-xs text-muted-foreground tracking-widest">{sentence.knowledgeSource}</span>
+                    </div>
                 </div>
-                <span className="text-2xl font-bold text-foreground">{sentence.sentence}</span>
-                <span className="text-base text-muted-foreground">{sentence.translation}</span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+                <span className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Main Translation</span>
+                <span className="text-lg font-bold">{sentence.sentence}</span>
             </div>
 
             {/* Alternatives list */}

--- a/app/language-learning/sentences/page.tsx
+++ b/app/language-learning/sentences/page.tsx
@@ -149,8 +149,12 @@ export default function SentencesPage() {
 }
 
 function SentenceRow({ sentence }: { sentence: SentenceWithStats }) {
+    const router = useRouter();
     return (
-        <div className="border-b border-cyan-600 py-2 flex flex-row items-center justify-between">
+        <div
+            className="border-b border-cyan-600 py-2 flex flex-row items-center justify-between cursor-pointer"
+            onClick={() => router.push(`/language-learning/sentences/${sentence.id}`)}
+        >
             <div className="flex flex-row items-center gap-2 flex-1 min-w-0 mr-3">
                 <div className="shrink-0">
                     {sentence.knowledgeSource == 'tome-agent' && <MaskedSvgIcon src="/images/agent.svg" alt="Tome Agent" />}

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -9,6 +9,7 @@ import { SessionProgressBar } from '@/components/SessionProgressBar';
 import { TranslationInput } from '@/components/TranslationInput';
 import { PracticeResult } from '@/app/components/PracticeResult';
 import { RoundButton } from 'toto-react';
+import { TomeLanguageAPI } from '@/api/TomeLanguageAPI';
 
 type ResultState = { isCorrect: boolean; userAnswer: string } | null;
 
@@ -34,6 +35,7 @@ export default function VocabularyPracticePage() {
     const [error, setError] = useState<string | null>(null);
     const [answer, setAnswer] = useState('');
     const [result, setResult] = useState<ResultState>(null);
+    const [acceptedThisWord, setAcceptedThisWord] = useState(false);
 
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -200,6 +202,7 @@ export default function VocabularyPracticePage() {
 
             setResult(null);
             setAnswer('');
+            setAcceptedThisWord(false);
         }
 
         nextFnRef.current = next;
@@ -215,6 +218,63 @@ export default function VocabularyPracticePage() {
         if (timerRef.current) clearTimeout(timerRef.current);
         nextFnRef.current?.();
     }, []);
+
+    const handleAcceptTranslation = () => {
+        const word = getCurrentWord();
+        if (!word || !session || !result || acceptedThisWord) return;
+
+        setAcceptedThisWord(true);
+
+        // Store the alternative — fire-and-forget
+        new TomeLanguageAPI().addWordAlternative('danish', word.id, result.userAnswer.trim())
+            .catch((e) => console.error('addWordAlternative failed:', e));
+
+        // Record a correct outcome in backend stats — fire-and-forget
+        api.submitAnswer(session.sessionId, word.id, true)
+            .catch((e) => console.error('submitAnswer (accept) failed:', e));
+
+        // Compute correct-answer queue delta
+        const currentFailedAttempts = Object.fromEntries(
+            session.words.map((w) => [w.id, w.failedAttempts])
+        );
+        const isFirstAttempt = !deferredIds.includes(word.id);
+        const nextMastered = [...masteredIds, word.id];
+        const nextFirstAttempt = isFirstAttempt ? [...firstAttemptCorrectIds, word.id] : firstAttemptCorrectIds;
+        const nextPending = pendingQueue.slice(1);
+        const nextDeferred = deferredIds.filter((id) => id !== word.id);
+
+        // Persist to localStorage
+        localStorage.setItem(`vocab-queue-${session.sessionId}`, JSON.stringify({
+            sessionId: session.sessionId,
+            pendingQueue: nextPending,
+            masteredIds: nextMastered,
+            deferredIds: nextDeferred,
+            firstAttemptCorrectIds: nextFirstAttempt,
+            wordFailedAttempts: currentFailedAttempts,
+        }));
+
+        // Update React state
+        setMasteredIds(nextMastered);
+        setDeferredIds(nextDeferred);
+        setFirstAttemptCorrectIds(nextFirstAttempt);
+        setPendingQueue(nextPending);
+        setSession((prev) => {
+            if (!prev) return prev;
+            return {
+                ...prev,
+                masteredIds: nextMastered,
+                deferredIds: nextDeferred,
+                firstAttemptCorrectIds: nextFirstAttempt,
+                pendingQueue: nextPending,
+            };
+        });
+
+        // Clear result and advance
+        if (timerRef.current) clearTimeout(timerRef.current);
+        setResult(null);
+        setAnswer('');
+        setAcceptedThisWord(false);
+    };
 
     /**
      * Handle "Enter" key to skip to next question immediately only: 
@@ -317,6 +377,16 @@ export default function VocabularyPracticePage() {
                                 </span>
                                 <PracticeResult type={result.isCorrect ? 'correct' : 'incorrect'} text={result.userAnswer} />
                                 {!result.isCorrect && (<PracticeResult type='reference' text={currentWord.translation} />)}
+                                {!result.isCorrect && !acceptedThisWord && (
+                                    <div className="flex flex-col items-center gap-2 mt-4">
+                                        <RoundButton
+                                            svgIconPath={{ src: '/images/point-right.svg', alt: 'Accept', color: 'bg-cyan-300' }}
+                                            onClick={handleAcceptTranslation}
+                                            type="primary"
+                                        />
+                                        <span className="text-sm text-muted-foreground">Accept my translation</span>
+                                    </div>
+                                )}
                             </div>
                         )}
                     </>

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -122,8 +122,10 @@ export default function VocabularyPracticePage() {
         if (!word || !session) return;
 
         const userAnswer = answer.trim();
+        const normalized = normalizeTranslationForComparison(userAnswer);
         const isCorrect =
-            normalizeTranslationForComparison(userAnswer) === normalizeTranslationForComparison(word.translation);
+            normalized === normalizeTranslationForComparison(word.translation) ||
+            word.alternativeTranslations.some((a) => normalized === normalizeTranslationForComparison(a.translation));
 
         setResult({ isCorrect, userAnswer });
 

--- a/app/language-learning/vocabulary/[wordId]/page.tsx
+++ b/app/language-learning/vocabulary/[wordId]/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useHeader } from '@/context/HeaderContext';
+import { TomeLanguageAPI, WordDetail, AlternativeTranslation } from '@/api/TomeLanguageAPI';
+import { MaskedSvgIcon } from '@/app/components/MaskedSvgIcon';
+import { RoundButton } from 'toto-react';
+
+export default function WordDetailPage() {
+    const router = useRouter();
+    const params = useParams();
+    const wordId = params.wordId as string;
+    const { setConfig } = useHeader();
+
+    const [word, setWord] = useState<WordDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [newAlt, setNewAlt] = useState('');
+    const [adding, setAdding] = useState(false);
+
+    useEffect(() => {
+        setConfig({
+            title: 'Word Details',
+            backButton: {
+                enabled: true,
+                onClick: () => router.push('/language-learning/vocabulary'),
+            },
+        });
+    }, [setConfig, router]);
+
+    const loadWord = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await new TomeLanguageAPI().getWord('danish', wordId);
+            setWord(data);
+        } catch (e) {
+            setError((e as Error).message ?? 'Failed to load word');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (wordId) loadWord();
+    }, [wordId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleRemoveAlternative = (alt: AlternativeTranslation) => {
+        if (!word) return;
+        // Optimistic remove
+        setWord((prev) => prev ? { ...prev, alternativeTranslations: prev.alternativeTranslations.filter((a) => a.id !== alt.id) } : prev);
+        new TomeLanguageAPI().removeWordAlternative('danish', wordId, alt.id)
+            .catch((e) => {
+                console.error('removeWordAlternative failed:', e);
+                // Revert on error
+                setWord((prev) => prev ? { ...prev, alternativeTranslations: [...prev.alternativeTranslations, alt] } : prev);
+            });
+    };
+
+    const handleAddAlternative = async () => {
+        const trimmed = newAlt.trim();
+        if (!trimmed || !word || adding) return;
+        setAdding(true);
+        setNewAlt('');
+        try {
+            const created = await new TomeLanguageAPI().addWordAlternative('danish', wordId, trimmed);
+            setWord((prev) => prev ? { ...prev, alternativeTranslations: [...prev.alternativeTranslations, created] } : prev);
+        } catch (e) {
+            console.error('addWordAlternative failed:', e);
+            setNewAlt(trimmed); // restore on error
+        } finally {
+            setAdding(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex flex-1 items-center justify-center">
+                <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-primary" />
+            </div>
+        );
+    }
+
+    if (error || !word) {
+        return (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+                <p className="text-destructive text-center">{error ?? 'Word not found'}</p>
+                <button onClick={loadWord} className="px-4 py-2 rounded-md bg-primary text-primary-foreground">
+                    Retry
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-1 flex-col items-stretch px-6 pt-8 gap-6 overflow-y-auto">
+            {/* Word header */}
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                    <MaskedSvgIcon
+                        src={word.knowledgeSource === 'tome-agent' ? '/images/agent.svg' : '/images/book.svg'}
+                        alt={word.knowledgeSource}
+                        size="w-5 h-5"
+                        color="bg-cyan-800"
+                    />
+                    <span className="text-xs text-muted-foreground uppercase tracking-widest">{word.knowledgeSource}</span>
+                </div>
+                <span className="text-3xl font-bold text-foreground">{word.translation}</span>
+                <span className="text-lg text-muted-foreground">{word.english}</span>
+            </div>
+
+            {/* Alternatives list */}
+            <div className="flex flex-col gap-2">
+                <span className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Alternative Translations</span>
+                {word.alternativeTranslations.length === 0 && (
+                    <p className="text-sm text-muted-foreground">No alternatives yet.</p>
+                )}
+                {word.alternativeTranslations.map((alt) => (
+                    <div key={alt.id} className="flex items-center justify-between border border-cyan-600 rounded-md px-4 py-2">
+                        <span className="text-sm text-foreground">{alt.translation}</span>
+                        <button
+                            onClick={() => handleRemoveAlternative(alt)}
+                            className="text-destructive text-xs ml-4 shrink-0"
+                            aria-label="Remove"
+                        >
+                            ✕
+                        </button>
+                    </div>
+                ))}
+            </div>
+
+            {/* Add new alternative */}
+            <div className="flex flex-col gap-3 pb-8">
+                <span className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Add Alternative</span>
+                <div className="flex items-center gap-3">
+                    <input
+                        type="text"
+                        value={newAlt}
+                        onChange={(e) => setNewAlt(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleAddAlternative(); }}
+                        placeholder="Type new translation…"
+                        className="flex-1 border border-cyan-600 rounded-full px-4 py-2 text-sm text-cyan-900 placeholder:text-cyan-700/50 focus:outline-none focus:border-lime-200 bg-transparent"
+                        disabled={adding}
+                    />
+                    <RoundButton
+                        svgIconPath={{ src: '/images/point-right.svg', alt: 'Add', color: 'bg-lime-200' }}
+                        onClick={handleAddAlternative}
+                        type="primary"
+                        loading={adding}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/language-learning/vocabulary/[wordId]/page.tsx
+++ b/app/language-learning/vocabulary/[wordId]/page.tsx
@@ -97,17 +97,23 @@ export default function WordDetailPage() {
         <div className="flex flex-1 flex-col items-stretch px-6 pt-8 gap-6 overflow-y-auto">
             {/* Word header */}
             <div className="flex flex-col gap-1">
-                <div className="flex items-center gap-2">
+                <div className="flex items-start gap-4">
                     <MaskedSvgIcon
                         src={word.knowledgeSource === 'tome-agent' ? '/images/agent.svg' : '/images/book.svg'}
                         alt={word.knowledgeSource}
                         size="w-5 h-5"
                         color="bg-cyan-800"
                     />
-                    <span className="text-xs text-muted-foreground uppercase tracking-widest">{word.knowledgeSource}</span>
+                    <div className='flex flex-col gap-1'>
+                        <span className="text-xl font-bold text-foreground">{word.english}</span>
+                        <span className="text-xs text-muted-foreground tracking-widest">{word.knowledgeSource}</span>
+                    </div>
                 </div>
-                <span className="text-3xl font-bold text-foreground">{word.translation}</span>
-                <span className="text-lg text-muted-foreground">{word.english}</span>
+            </div>
+
+            <div className="flex flex-col gap-2">
+                <span className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">Main Translation</span>
+                <span className="text-lg font-bold">{word.translation}</span>
             </div>
 
             {/* Alternatives list */}

--- a/app/language-learning/vocabulary/page.tsx
+++ b/app/language-learning/vocabulary/page.tsx
@@ -163,8 +163,12 @@ export default function VocabularyPage() {
 }
 
 function WordItem({ word }: { word: WordWithStats }) {
+    const router = useRouter();
     return (
-        <div className="flex items-center justify-between">
+        <div
+            className="flex items-center justify-between cursor-pointer"
+            onClick={() => router.push(`/language-learning/vocabulary/${word.id}`)}
+        >
             <div>
                 <div className="text-grey-900 font-bold text-lg">
                     {word.translation}

--- a/docs/specs/language-learning/alternative-translations-accept-button.md
+++ b/docs/specs/language-learning/alternative-translations-accept-button.md
@@ -1,0 +1,39 @@
+# Spec: Alternative Translations — Vocabulary Practice "Accept my translation" button
+
+## Objective
+After a failed vocabulary attempt, show a "✓ Accept my translation" button that lets the learner store their answer as a community alternative and immediately advance the queue as if the answer were correct. This is the primary self-acceptance flow for vocabulary alternatives — no AI gate needed because strict word-level matching already acts as a soft quality bar.
+
+## Core Logic
+
+### Where
+`app/language-learning/vocabulary-practice/page.tsx`
+
+### State
+Add a boolean state `acceptedThisWord` (default `false`). Reset to `false` whenever `result` is reset to `null`.
+
+### Button visibility
+The button is shown in the result area when **all three** are true:
+- `result !== null`
+- `result.isCorrect === false`
+- `acceptedThisWord === false`
+
+It disappears once clicked (set `acceptedThisWord = true`).
+
+### On click — `handleAcceptTranslation`
+1. Set `acceptedThisWord = true` (prevents double-click).
+2. Call `new TomeLanguageAPI().addWordAlternative('danish', word.id, result.userAnswer.trim())` — **fire-and-forget** (log error, never block UX).
+3. Call `api.submitAnswer(session.sessionId, word.id, true)` — **fire-and-forget** (same pattern as the existing incorrect-answer submit).
+4. Compute the correct queue delta (same logic as `isCorrect === true` in `handleSubmit`): move the word from pending to mastered, mark first-attempt-correct only if this is the first attempt. Persist the updated queue state to localStorage.
+5. Update React state (masteredIds, deferredIds, firstAttemptCorrectIds, pendingQueue, session) to reflect the word as mastered.
+6. Advance to the next word (clear result + answer) — same as the `next()` callback inside `handleSubmit` for a correct answer.
+
+### Design
+- The button is placed **in the result area** (not in the bottom bar).
+- Visually distinct from the "Next" arrow button; use a checkmark icon (e.g. `/images/point-right.svg` style — use `RoundButton` from `toto-react`).
+- Use label text "Accept my translation" beneath or beside the button.
+
+## Out of Scope
+- Showing the button after a correct answer.
+- Any undo / retract mechanism.
+- AI validation of accepted vocabulary words.
+- Sentence practice (sentence acceptance is handled via issue #256 / the AI cascade).

--- a/docs/specs/language-learning/alternative-translations-ai-storage.md
+++ b/docs/specs/language-learning/alternative-translations-ai-storage.md
@@ -1,0 +1,39 @@
+# Spec: Alternative Translations — Store AI-Corrected Alternatives in Sentence Practice
+
+## Objective
+When the AI cascade accepts a sentence translation, automatically store the AI-corrected version as a community alternative. Extend the `/api/llm-verify` route and `LLMVerifyResult` type to return a `correctedTranslation` field containing the learner's answer with grammar/spelling corrections applied.
+
+## Core Logic
+
+### `app/api/llm-verify/route.ts`
+
+#### `buildPrompt` update
+Add the following instruction to the prompt:
+> When acceptable is true, also return correctedTranslation: the learner's answer with any spelling or grammar mistakes fixed, without changing the meaning or phrasing. If no corrections are needed, return the learner's answer unchanged.
+
+Updated JSON schema in prompt:
+```
+{"acceptable": true|false, "explanation": "<one sentence>", "correctedTranslation": "<string>"}
+```
+`correctedTranslation` is present only when `acceptable: true`.
+
+#### `callGemini` update
+- Extract `correctedTranslation` from the parsed response (optional string, absent when `acceptable: false`).
+- Return type becomes `{ acceptable: boolean; explanation: string; correctedTranslation?: string }`.
+- Validation: if `acceptable: true` but `correctedTranslation` is absent/null, treat as empty (fallback handled in caller).
+
+### `api/TomeLLMVerifyAPI.ts`
+Add `correctedTranslation?: string` to `LLMVerifyResult`.
+
+### `app/language-learning/sentence-practice/page.tsx` — `handleAskAI`
+After `verdict.acceptable === true` and the correct delta is computed:
+```ts
+new TomeLanguageAPI().addSentenceAlternative('danish', sentence.id, verdict.correctedTranslation ?? result.userAnswer)
+    .catch((e) => console.error('addSentenceAlternative failed:', e));
+```
+Fire-and-forget. Does not affect practice flow.
+
+## Out of Scope
+- Showing the corrected translation in the UI (the LLM result card already shows the explanation).
+- AI validation for vocabulary words.
+- "Accept my translation" button for sentence practice (AI gate is the acceptance mechanism for sentences).

--- a/docs/specs/language-learning/alternative-translations-core-logic.md
+++ b/docs/specs/language-learning/alternative-translations-core-logic.md
@@ -1,0 +1,133 @@
+# Spec: Alternative Translations — Frontend Core Logic
+
+## Objective
+
+Update the frontend session models, matching logic, and API client to support alternative translations. This is the foundational frontend change that all other frontend alternative-translations tasks build on.
+
+Covers: `tome#254`
+
+## Core Logic
+
+### 1. Model updates
+
+Add `alternativeTranslations` to both practice models:
+
+**`model/VocabularyPractice.ts`**
+```
+VocabPracticeWord.alternativeTranslations: Array<{ id: string; translation: string }>
+```
+
+**`model/SentencePractice.ts`**
+```
+SentencePracticeSentence.alternativeTranslations: Array<{ id: string; translation: string }>
+```
+
+Default to `[]` when absent — backward compatible with any cached state.
+
+### 2. API client updates
+
+**`api/TomeVocabularyPracticeAPI.ts`**
+- Extend `BackendWord` interface: add `alternativeTranslations?: Array<{ id: string; translation: string }>`
+- Update `mapBackendWords`: map `alternativeTranslations: w.alternativeTranslations ?? []` into each `VocabPracticeWord`
+
+**`api/TomeSentencePracticeAPI.ts`**
+- Extend `BackendSentence` interface: add `alternativeTranslations?: Array<{ id: string; translation: string }>`
+- Update `mapBackendSentences`: map `alternativeTranslations: s.alternativeTranslations ?? []` into each `SentencePracticeSentence`
+
+### 3. Matching logic updates
+
+**Vocabulary practice (`app/language-learning/vocabulary-practice/page.tsx`)**
+
+Current matching:
+```ts
+const isCorrect = normalize(userAnswer) === normalize(word.translation);
+```
+
+Updated matching:
+```ts
+const isCorrect =
+    normalize(userAnswer) === normalize(word.translation) ||
+    word.alternativeTranslations.some(a => normalize(userAnswer) === normalize(a.translation));
+```
+
+**Sentence practice (`app/language-learning/sentence-practice/page.tsx`)**
+
+Current Tier 1 + Tier 2:
+```ts
+const tier1 = normalize(userAnswer) === normalize(sentence.translation);
+const tier2 = levenshteinDistance(...) / maxLen <= THRESHOLD;
+const isCorrect = tier1 || tier2;
+```
+
+Updated to also check each alternative with both tiers:
+```ts
+const tier1 = matchesTier1(userAnswer, sentence.translation) ||
+    sentence.alternativeTranslations.some(a => matchesTier1(userAnswer, a.translation));
+const tier2 = !tier1 && (matchesTier2(userAnswer, sentence.translation) ||
+    sentence.alternativeTranslations.some(a => matchesTier2(userAnswer, a.translation)));
+const isCorrect = tier1 || tier2;
+```
+
+Extract `matchesTier1` and `matchesTier2` helper functions (or inline — same result as long as Tier 2 is only applied when Tier 1 fails, matching current behaviour).
+
+### 4. New TomeLanguageAPI methods
+
+Add to `api/TomeLanguageAPI.ts`:
+
+```ts
+addWordAlternative(language, wordId, translation): Promise<{ id: string; translation: string }>
+  → POST /vocabulary/:language/words/:wordId/alternatives
+
+removeWordAlternative(language, wordId, id): Promise<void>
+  → DELETE /vocabulary/:language/words/:wordId/alternatives/:id
+
+addSentenceAlternative(language, sentenceId, translation): Promise<{ id: string; translation: string }>
+  → POST /sentences/:language/:sentenceId/alternatives
+
+removeSentenceAlternative(language, sentenceId, id): Promise<void>
+  → DELETE /sentences/:language/:sentenceId/alternatives/:id
+
+getWord(language, wordId): Promise<WordDetail>
+  → GET /vocabulary/:language/words/:wordId
+
+getSentence(language, sentenceId): Promise<SentenceDetail>
+  → GET /sentences/:language/:sentenceId
+```
+
+Add `WordDetail` and `SentenceDetail` interfaces:
+
+```ts
+export interface WordDetail {
+    id: string;
+    language: string;
+    english: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
+}
+
+export interface SentenceDetail {
+    id: string;
+    language: string;
+    sentence: string;
+    translation: string;
+    createdAt: string;
+    knowledgeSource: string;
+    alternativeTranslations: Array<{ id: string; translation: string }>;
+}
+```
+
+Also add `alternativeTranslations` to existing `WordWithStats` and `SentenceWithStats` interfaces (they are returned by the backend with-stats endpoints which now include the field).
+
+### Architectural Decisions
+
+- **`alternativeTranslations` defaults to `[]`** everywhere: in `mapBackendWords`, `mapBackendSentences`, and model constructors. This ensures backward compatibility with existing sessions in localStorage.
+- **Matching logic is purely additive**: alternative matching is checked *in addition to* canonical translation. The result is the same boolean `isCorrect` — no other downstream logic changes.
+- **Tier ordering preserved in sentence practice**: Tier 2 (fuzzy) is only attempted if Tier 1 (exact) fails across *all* candidates (canonical + alternatives). This preserves the existing behaviour that a close-enough answer gets accepted at Tier 2.
+
+## Out of Scope
+
+- The "Accept my translation" button UI (covered in `tome#255`)
+- AI-corrected alternative storage (covered in `tome#256`)
+- Detail pages (covered in `tome#257`, `tome#258`)

--- a/docs/specs/language-learning/alternative-translations-sentence-detail-page.md
+++ b/docs/specs/language-learning/alternative-translations-sentence-detail-page.md
@@ -1,0 +1,32 @@
+# Spec: Alternative Translations — Sentence Detail Page
+
+## Objective
+Add a sentence detail page at `/language-learning/sentences/[sentenceId]` where learners can view and manage alternative translations for a sentence. Make sentence list rows navigable to this page.
+
+## Core Logic
+
+### New page: `app/language-learning/sentences/[sentenceId]/page.tsx`
+
+#### Data fetching
+- On mount: `new TomeLanguageAPI().getSentence('danish', sentenceId)` → `SentenceDetail`.
+- Show loading skeleton while fetching.
+- Show error state on failure with a retry button.
+
+#### Content
+- Header area: Danish sentence (large, bold), English translation (medium), knowledgeSource badge.
+- `knowledgeSource` badge: use local `MaskedSvgIcon` from `@/app/components/MaskedSvgIcon` (NOT from toto-react). `tome-agent` → `agent.svg`; otherwise → `book.svg`. Tailwind `bg-*` and `w-/h-` classes for color/size.
+- Alternatives list: each row shows `translation` text + a small remove icon button. On click: call `removeSentenceAlternative('danish', sentenceId, alt.id)` fire-and-forget, update local state optimistically; on error, re-add.
+- Add-new form at the bottom: `<input>` for text + `RoundButton` (from `toto-react`) to confirm. On confirm: call `addSentenceAlternative('danish', sentenceId, inputValue.trim())` fire-and-forget, append to list optimistically; clear input. On error, remove temporary entry.
+- Back button in header: `router.push('/language-learning/sentences')`.
+
+### Sentences list navigation
+In `app/language-learning/sentences/page.tsx`, make `SentenceRow` clickable:
+```tsx
+<div ... onClick={() => router.push(`/language-learning/sentences/${sentence.id}`)} className="... cursor-pointer">
+```
+Pass `router` from the parent page via props or use `useRouter()` inside `SentenceRow`.
+
+## Out of Scope
+- Practice stats on the detail page.
+- Editing the canonical sentence or translation.
+- Pagination of alternatives.

--- a/docs/specs/language-learning/alternative-translations-word-detail-page.md
+++ b/docs/specs/language-learning/alternative-translations-word-detail-page.md
@@ -1,0 +1,32 @@
+# Spec: Alternative Translations — Word Detail Page
+
+## Objective
+Add a word detail page at `/language-learning/vocabulary/[wordId]` where learners can view and manage alternative translations for a vocabulary word. Make vocabulary list items navigable to this page.
+
+## Core Logic
+
+### New page: `app/language-learning/vocabulary/[wordId]/page.tsx`
+
+#### Data fetching
+- On mount: `new TomeLanguageAPI().getWord('danish', wordId)` → `WordDetail`.
+- Show loading skeleton while fetching.
+- Show error state on failure with a retry button.
+
+#### Content
+- Header area: English word (large, bold), canonical translation (medium), knowledgeSource badge.
+- `knowledgeSource` badge: use local `MaskedSvgIcon` from `@/app/components/MaskedSvgIcon` (NOT from toto-react). `tome-agent` → `agent.svg`; otherwise → `book.svg`. Use Tailwind `bg-*` and `w-/h-` classes for color/size.
+- Alternatives list: each row shows `translation` text + a small remove icon button. On click: call `removeWordAlternative('danish', wordId, alt.id)` fire-and-forget, update local state optimistically (remove immediately); on error, re-add to list.
+- Add-new form at the bottom: `<input>` for text + `RoundButton` (from `toto-react`) to confirm. On confirm: call `addWordAlternative('danish', wordId, inputValue.trim())` fire-and-forget, append returned object to list optimistically (generate a temporary id if needed); clear input. On error, remove temporary entry.
+- Back button in header: `router.push('/language-learning/vocabulary')`.
+
+### Vocabulary list navigation
+In `app/language-learning/vocabulary/page.tsx`, make `WordItem` clickable:
+```tsx
+<div ... onClick={() => router.push(`/language-learning/vocabulary/${word.id}`)} className="... cursor-pointer">
+```
+Pass `router` from the parent page via props or use `useRouter()` inside `WordItem`.
+
+## Out of Scope
+- Practice stats on the detail page.
+- Editing the canonical translation.
+- Pagination of alternatives (expected to be a short list).

--- a/model/SentencePractice.ts
+++ b/model/SentencePractice.ts
@@ -3,6 +3,7 @@ export interface SentencePracticeSentence {
   sentence: string;
   translation: string;
   failedAttempts: number;
+  alternativeTranslations: Array<{ id: string; translation: string }>;
 }
 
 export interface SentencePracticeSession {

--- a/model/VocabularyPractice.ts
+++ b/model/VocabularyPractice.ts
@@ -3,6 +3,7 @@ export interface VocabPracticeWord {
   english: string;
   translation: string;
   failedAttempts: number;
+  alternativeTranslations: Array<{ id: string; translation: string }>;
 }
 
 export interface VocabPracticeSession {


### PR DESCRIPTION
## Summary

Implements the frontend for the Alternative Translations feature (#253).

## Issues Closed

- Closes #254 — Core logic: `alternativeTranslations` in models, API clients, practice matching
- Closes #255 — Vocabulary practice: 'Accept my translation' button
- Closes #256 — Sentence practice: store AI-corrected alternatives via LLM cascade
- Closes #257 — Word detail page at `/language-learning/vocabulary/[wordId]`
- Closes #258 — Sentence detail page at `/language-learning/sentences/[sentenceId]`

## Changes

### Core Logic (#254)
- `VocabPracticeWord` and `SentencePracticeSentence` models: added `alternativeTranslations` field
- `TomeVocabularyPracticeAPI` and `TomeSentencePracticeAPI`: carry `alternativeTranslations` from backend
- Vocabulary practice: matching checks canonical + all alternatives
- Sentence practice: Tier1/Tier2 matching checks canonical + all alternatives (Tier2 only fires if Tier1 fails everywhere)
- `TomeLanguageAPI`: added `getWord`, `getSentence`, `addWordAlternative`, `removeWordAlternative`, `addSentenceAlternative`, `removeSentenceAlternative` methods + new interfaces

### Accept Button (#255)
- After a wrong answer, shows 'Accept my translation' button (one-shot) in the result area
- On click: stores alternative fire-and-forget, submits correct outcome, advances the queue as if correct

### AI-Corrected Alternative Storage (#256)
- `/api/llm-verify` prompt updated to return `correctedTranslation` when acceptable
- `LLMVerifyResult` extended with `correctedTranslation?: string`
- `handleAskAI`: when AI accepts, stores the corrected translation as a sentence alternative (fire-and-forget)

### Detail Pages (#257, #258)
- Word list items are now clickable → navigate to `/language-learning/vocabulary/[wordId]`
- Sentence list rows are now clickable → navigate to `/language-learning/sentences/[sentenceId]`
- Both detail pages: show word/sentence info with knowledge source badge, list of alternatives (with remove), add-new form

## Specs
- `docs/specs/language-learning/alternative-translations-core-logic.md`
- `docs/specs/language-learning/alternative-translations-accept-button.md`
- `docs/specs/language-learning/alternative-translations-ai-storage.md`
- `docs/specs/language-learning/alternative-translations-word-detail-page.md`
- `docs/specs/language-learning/alternative-translations-sentence-detail-page.md`

Depends on: nicolasances/tome-ms-language#32