### PR TITLE
feat: Language Learning responsiveness for larger screens

### DIFF
--- a/app/language-learning/knowledge-base/page.tsx
+++ b/app/language-learning/knowledge-base/page.tsx
@@ -21,7 +21,7 @@ export default function KnowledgeBasePage() {
     }, [setConfig, router]);
 
     return (
-        <div className="flex flex-1 flex-col items-stretch justify-start px-4 pt-8">
+        <div className="flex flex-1 flex-col items-stretch justify-start px-4 pt-8 md:self-center md:max-w-2xl md:w-full">
             <div className="flex flex-col gap-3">
                 <KnowledgeBaseRow
                     icon="/images/book.svg"

--- a/app/language-learning/page.tsx
+++ b/app/language-learning/page.tsx
@@ -43,7 +43,7 @@ export default function LanguageLearningPage() {
     const activeType = activeSession?.practiceType ?? null;
 
     return (
-        <div className="flex flex-1 flex-col items-stretch justify-start">
+        <div className="flex flex-1 flex-col items-stretch justify-start md:self-center md:max-w-2xl md:w-full">
             <div className="flex-1 flex flex-col items-center px-4">
                 {/* Top icon buttons */}
                 <div className="flex items-center justify-center mt-8 gap-4">

--- a/app/language-learning/sentence-practice/page.tsx
+++ b/app/language-learning/sentence-practice/page.tsx
@@ -375,7 +375,7 @@ export default function SentencePracticePage() {
     const showContinue = result !== null && !llmVerifying && !shouldAutoContinue;
 
     return (
-        <div className="flex flex-col items-stretch h-full">
+        <div className="flex flex-col items-stretch h-full md:self-center md:max-w-2xl md:w-full">
             <div className="px-4 pt-8">
                 <SessionProgressBar
                     total={session.totalSentences}
@@ -420,7 +420,7 @@ export default function SentencePracticePage() {
                 )}
             </div>
 
-            <div className="fixed bottom-0 left-0 right-0 p-4 bg-background">
+            <div className="p-4 bg-background">
                 <div className="flex items-center gap-3">
                     <div className="flex-1 min-w-0">
                         <TranslationInput

--- a/app/language-learning/sentence-summary/page.tsx
+++ b/app/language-learning/sentence-summary/page.tsx
@@ -46,7 +46,7 @@ export default function SentenceSummaryPage() {
     const failedSentences = summary.sentenceResults.filter((s) => s.failedAttempts > 0);
 
     return (
-        <div className="flex flex-1 flex-col items-stretch px-6 py-8 gap-8">
+        <div className="flex flex-1 flex-col items-stretch px-6 py-8 gap-8 md:self-center md:max-w-2xl md:w-full">
             {/* Score summary */}
             <div className="flex flex-col items-center gap-4">
                 <div className="text-muted-foreground text-xs uppercase tracking-widest">You scored</div>

--- a/app/language-learning/summary/page.tsx
+++ b/app/language-learning/summary/page.tsx
@@ -46,7 +46,7 @@ export default function SessionSummaryPage() {
     const failedWords = summary.wordResults.filter((w) => w.failedAttempts > 0);
 
     return (
-        <div className="flex flex-1 flex-col items-stretch px-6 py-8 gap-8">
+        <div className="flex flex-1 flex-col items-stretch px-6 py-8 gap-8 md:self-center md:max-w-2xl md:w-full">
             {/* Score summary */}
             <div className="flex flex-col items-center gap-4">
                 <div className="text-muted-foreground text-xs uppercase tracking-widest">You scored</div>

--- a/app/language-learning/vocabulary-practice/page.tsx
+++ b/app/language-learning/vocabulary-practice/page.tsx
@@ -344,7 +344,7 @@ export default function VocabularyPracticePage() {
     const currentWord = getCurrentWord();
 
     return (
-           <div className="flex flex-col items-stretch h-full">
+           <div className="flex flex-col items-stretch h-full md:self-center md:max-w-2xl md:w-full">
 
             {/* Progress bar */}
             <div className="px-4 pt-8">
@@ -394,7 +394,7 @@ export default function VocabularyPracticePage() {
             </div>
 
             {/* Input pinned at bottom */}
-            <div className="fixed bottom-0 left-0 right-0 p-4 bg-background">
+            <div className="p-4 bg-background">
                 <div className="flex items-center gap-3">
                     <div className="flex-1 min-w-0">
                         <TranslationInput

--- a/docs/specs/language-learning/responsiveness-hub-summary-pages.md
+++ b/docs/specs/language-learning/responsiveness-hub-summary-pages.md
@@ -1,0 +1,49 @@
+# Spec: Responsive Language Learning Hub, Knowledge Base & Summary Pages
+
+**Related issues:** [#262](https://github.com/nicolasances/tome/issues/262), [#260](https://github.com/nicolasances/tome/issues/260)
+
+## Objective
+
+Make the Language Learning hub, knowledge base and session summary pages look good on screens larger than mobile. These pages don't have the fixed-positioning bug of the practice pages, but their content stretches across the full content column on wide screens.
+
+The goal is two-size responsiveness:
+1. **Mobile (< 768px / `md` breakpoint):** keep the existing layout exactly as-is.
+2. **Larger-than-mobile (≥ 768px):** content is centered with a max-width cap.
+
+---
+
+## Core Logic
+
+### Breakpoint Strategy
+
+Use Tailwind's `md` breakpoint (768px) as the single threshold. No other breakpoints needed.
+
+### Max-Width Centering
+
+For each page, wrap the page body content in a `max-w-2xl mx-auto w-full` container that activates at `md+`. This ensures content is centered in the middle of the column rather than stretching edge-to-edge.
+
+### Changes Required
+
+#### `app/language-learning/page.tsx` (Hub)
+
+- Wrap the inner content `div` with `md:max-w-2xl md:mx-auto md:w-full`.
+
+#### `app/language-learning/knowledge-base/page.tsx`
+
+- Wrap the row list container with `md:max-w-2xl md:mx-auto md:w-full`.
+
+#### `app/language-learning/summary/page.tsx` (Vocab Session Summary)
+
+- Wrap the content with `md:max-w-2xl md:mx-auto md:w-full`.
+
+#### `app/language-learning/sentence-summary/page.tsx` (Sentence Session Summary)
+
+- Wrap the content with `md:max-w-2xl md:mx-auto md:w-full`.
+
+---
+
+## Out of Scope
+
+- Practice pages (vocabulary-practice, sentence-practice) — covered by a separate spec
+- Vocabulary list, sentences list, sources pages
+- Any change to the root `layout.tsx`

--- a/docs/specs/language-learning/responsiveness-practice-pages.md
+++ b/docs/specs/language-learning/responsiveness-practice-pages.md
@@ -1,0 +1,66 @@
+# Spec: Responsive Language Learning Practice Pages
+
+**Related issues:** [#261](https://github.com/nicolasances/tome/issues/261), [#260](https://github.com/nicolasances/tome/issues/260)
+
+## Objective
+
+Make the Vocabulary Practice and Sentence Practice pages responsive so they look and work correctly on screens larger than a mobile phone (laptops, tablets, desktop).
+
+Currently both practice pages have a bottom input bar that uses `fixed bottom-0 left-0 right-0`, causing it to span the full viewport width — including the side panels introduced by the root layout at `xl`/`2xl` breakpoints. On a laptop, this is visually broken.
+
+The goal is two-size responsiveness:
+1. **Mobile (< 768px / `md` breakpoint):** keep the existing layout exactly as-is.
+2. **Larger-than-mobile (≥ 768px):** content and input bar are centered within the content column, with a max-width cap.
+
+---
+
+## Core Logic
+
+### Breakpoint Strategy
+
+Use Tailwind's `md` breakpoint (768px) as the single threshold between mobile and non-mobile layouts. No intermediate or larger breakpoints are needed.
+
+### Bottom Input Bar — Replace `fixed` with flex-child
+
+The current `fixed bottom-0 left-0 right-0` positions the bar relative to the viewport, bypassing all layout containers. This is the root cause of the desktop breakage.
+
+**Fix:** Remove `fixed` entirely. The practice page root div already uses `h-full` with `flex flex-col`, so the bottom bar naturally sticks to the bottom when placed as the last flex child. No layout changes are needed to the parent — just remove the `fixed` positioning.
+
+On mobile, the behavior is identical: the bar stays at the bottom of the full-height page. On desktop, it stays within the content column.
+
+### Max-Width Centering
+
+On `md+` screens, constrain the practice content and input bar to `max-w-2xl` centered horizontally (`mx-auto`), so the content doesn't stretch awkwardly across a wide column.
+
+Both the scrollable content area and the bottom bar should share the same max-width wrapper to stay visually aligned.
+
+### Changes Required
+
+#### `app/language-learning/vocabulary-practice/page.tsx`
+
+1. **Bottom bar:** change from:
+   ```tsx
+   <div className="fixed bottom-0 left-0 right-0 p-4 bg-background">
+   ```
+   to a non-fixed flex child:
+   ```tsx
+   <div className="p-4 bg-background">
+   ```
+
+2. **Content area:** add `md:max-w-2xl md:mx-auto w-full` to the main content wrapper and the bottom bar wrapper.
+
+3. **Outer container:** add a wrapper div with `md:max-w-2xl md:mx-auto md:w-full` that groups both the content area and the bottom bar, so they share the same horizontal centering.
+
+#### `app/language-learning/sentence-practice/page.tsx`
+
+Identical changes to vocabulary-practice.
+
+---
+
+## Out of Scope
+
+- Knowledge base, vocabulary list, sentences list, sources pages
+- Summary pages (covered by a separate spec)
+- Any change to the root `layout.tsx`
+- Screen sizes between `md` and `xl` are not special-cased; the same rules apply to all non-mobile sizes
+- No typography size changes — font sizes remain as-is


### PR DESCRIPTION
## Summary

Makes all Language Learning pages responsive for screens larger than mobile.

Closes #261
Closes #262

Related to #260

## Changes

### Practice Pages (fixes #261)

**`vocabulary-practice/page.tsx`** and **`sentence-practice/page.tsx`**:
- Removed `fixed bottom-0 left-0 right-0` from the bottom input bar. The page root is already `h-full flex flex-col`, so the bar naturally sticks to the bottom as a flex child — no layout change needed on mobile.
- Added `md:self-center md:max-w-2xl md:w-full` to the page root so the entire practice area (progress bar, content, input) is centered with a 672px cap on larger screens.

### Hub, Knowledge Base & Summary Pages (fixes #262)

**`language-learning/page.tsx`**, **`knowledge-base/page.tsx`**, **`summary/page.tsx`**, **`sentence-summary/page.tsx`**:
- Added `md:self-center md:max-w-2xl md:w-full` to the root content div on each page for the same centering effect.

### Specs

Two spec files were added:
- `docs/specs/language-learning/responsiveness-practice-pages.md`
- `docs/specs/language-learning/responsiveness-hub-summary-pages.md`

## Approach

Uses Tailwind's `md` breakpoint (768px) as the single mobile/non-mobile boundary.  `align-self: center` + `max-w-2xl` + `w-full` on a flex-column child correctly centers content within the content column without any JavaScript.