### PR TITLE
Feature 04: Grammar Introduction — module step 1

### DIFF
--- a/api/TomeLearningDashboardAPI.ts
+++ b/api/TomeLearningDashboardAPI.ts
@@ -6,10 +6,23 @@ import { TotoAPI } from "./TotoAPI";
  * Wraps the tome-ms-language backend.
  *
  * Endpoint mapping (basepath handled by NEXT_PUBLIC_TOME_LANGUAGE_API_ENDPOINT):
+ *   - GET /me                    → user profile (id, email, cefrLevel)
  *   - GET /me/progress               → level info + modules at current level
  *   - GET /sessions/stats/weekly     → session counts per day for current week
  */
 export class TomeLearningDashboardAPI {
+
+    /**
+     * Fetches the authenticated user's profile.
+     * Returns the user's internal ID, email, and current CEFR level.
+     * The userId is required when calling user-scoped endpoints such as
+     * POST /users/:userId/modules/:moduleId/practiceSessions.
+     *
+     * Endpoint: GET /me
+     */
+    async getMe(): Promise<MeResponse> {
+        return (await new TotoAPI().fetch('tome-ms-language', '/me')).json();
+    }
 
     /**
      * Fetches the user's full progress view.
@@ -37,6 +50,14 @@ export class TomeLearningDashboardAPI {
 }
 
 // ─── Raw API response types (matching tome-ms-language exactly) ────────────
+
+export interface MeResponse {
+    /** The user's internal database ID — required for user-scoped endpoints */
+    id: string;
+    email: string;
+    cefrLevel: string;
+    createdAt: string;
+}
 
 export interface MeProgressResponse {
     /** The user's current CEFR level, e.g. "A1" */

--- a/api/TomeModuleAPI.ts
+++ b/api/TomeModuleAPI.ts
@@ -5,7 +5,8 @@ import { TotoAPI } from "./TotoAPI";
  * Wraps the tome-ms-language backend.
  *
  * Endpoint mapping (basepath handled by NEXT_PUBLIC_TOME_LANGUAGE_API_ENDPOINT):
- *   - GET /modules/:id   → full module document for the Module Overview screen
+ *   - GET /modules/:id                        → full module document for the Module Overview screen
+ *   - GET /modules/:moduleId/grammarIntroduction → grammar concepts for Step 1 (F04)
  */
 export class TomeModuleAPI {
 
@@ -19,9 +20,46 @@ export class TomeModuleAPI {
     async getModule(moduleId: string): Promise<ModuleResponse> {
         return (await new TotoAPI().fetch('tome-ms-language', `/modules/${moduleId}`)).json();
     }
+
+    /**
+     * Fetches the module's grammar concepts for the Grammar Introduction screen (Step 1).
+     * Returns concepts in presentation order (mirrors grammarConceptIds order on the module).
+     * Each concept carries a pre-generated explanation and 1–2 Danish/English example pairs.
+     * This endpoint is read-only — no backend write occurs.
+     *
+     * Endpoint: GET /modules/:moduleId/grammarIntroduction
+     */
+    async getGrammarIntroduction(moduleId: string): Promise<GrammarIntroductionResponse> {
+        return (await new TotoAPI().fetch('tome-ms-language', `/modules/${moduleId}/grammarIntroduction`)).json();
+    }
 }
 
 // ─── API response types ────────────────────────────────────────────────────────
+
+// ── Grammar Introduction ──────────────────────────────────────────────────────
+
+export interface GrammarExample {
+    /** Danish sentence illustrating the concept */
+    danish: string;
+    /** English translation of the Danish example */
+    english: string;
+}
+
+export interface GrammarConcept {
+    /** Concept name, e.g. "Present Tense — at være" */
+    name: string;
+    /** Pre-generated explanation stored at seeding time; never regenerated live */
+    explanation: string;
+    /** 1–2 bilingual examples for the concept */
+    examples: GrammarExample[];
+}
+
+export interface GrammarIntroductionResponse {
+    /** Grammar concepts in presentation order (mirrors grammarConceptIds on the module) */
+    concepts: GrammarConcept[];
+}
+
+// ── Module ────────────────────────────────────────────────────────────────────
 
 export interface ModuleResponse {
     id: string;

--- a/api/TomePracticeSessionAPI.ts
+++ b/api/TomePracticeSessionAPI.ts
@@ -1,0 +1,53 @@
+import { TotoAPI } from "./TotoAPI";
+
+/**
+ * API class for module-scoped practice sessions (F10 / F04 exit).
+ * Wraps the tome-ms-language backend.
+ *
+ * Endpoint mapping (basepath handled by NEXT_PUBLIC_TOME_LANGUAGE_API_ENDPOINT):
+ *   - POST /users/:userId/modules/:moduleId/practiceSessions  → start a new session
+ */
+export class TomePracticeSessionAPI {
+
+    /**
+     * Starts a new practice session for the given user and module.
+     *
+     * Called at the end of the Grammar Introduction step (F04) to transition the
+     * module into its practice phase. This call also flips UserModuleProgress to
+     * "in_progress" on the backend (F10 business logic).
+     *
+     * Returns null when a session is already active for this module (HTTP 409) —
+     * the caller should navigate to the practice screen regardless, where the
+     * existing session will be loaded.
+     *
+     * Endpoint: POST /users/:userId/modules/:moduleId/practiceSessions
+     */
+    async startPracticeSession(userId: string, moduleId: string): Promise<StartPracticeSessionResponse | null> {
+        const response = await new TotoAPI().fetch(
+            'tome-ms-language',
+            `/users/${userId}/modules/${moduleId}/practiceSessions`,
+            { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+        );
+
+        if (response.status === 409) {
+            // An active session already exists — navigate to practice anyway
+            return null;
+        }
+
+        if (!response.ok) {
+            throw new Error(`Failed to start practice session (${response.status})`);
+        }
+
+        return response.json();
+    }
+}
+
+// ─── API response types ────────────────────────────────────────────────────────
+
+export interface StartPracticeSessionResponse {
+    sessionId: string;
+    moduleId: string;
+    /** Ordered list of exercise IDs for this session */
+    exerciseIds: string[];
+    startedAt: string;
+}

--- a/app/language-learning/module/[moduleId]/components/StepList.tsx
+++ b/app/language-learning/module/[moduleId]/components/StepList.tsx
@@ -15,7 +15,7 @@ function StepMedallion({number, state}: {number: number, state: StepState}) {
 
     return (
         <div className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 text-[13px] font-bold ${isLime ? 'bg-lime-200' : 'bg-transparent'} ${isLime ? '' : state === 'locked' ? 'border-2 border-black/20' : 'border-2 border-cyan-600'} ${state === 'locked' ? 'text-black/50' : 'text-cyan-800'}`}>
-            {state === 'completed' ? '✓' : number}
+            {state === 'completed' ? <MaskedSvgIcon src='/images/tick.svg' alt='Completed' /> : number}
         </div>
     );
 }

--- a/app/language-learning/module/[moduleId]/grammar/components/ConceptCard.tsx
+++ b/app/language-learning/module/[moduleId]/grammar/components/ConceptCard.tsx
@@ -27,7 +27,7 @@ export function ConceptCard({ name, explanation, examples }: GrammarConcept) {
                         color="bg-cyan-800"
                     />
                 </div>
-                <h2 className="text-lg font-bold text-black/80 leading-tight">{name}</h2>
+                <div className="text-lg font-bold text-black/80 leading-tight">{name}</div>
             </div>
 
             {/* ── Explanation ─────────────────────────────────────────────── */}
@@ -38,8 +38,8 @@ export function ConceptCard({ name, explanation, examples }: GrammarConcept) {
                 <div className="flex flex-col gap-3 mt-4">
                     {examples.map((ex, i) => (
                         <div key={i} className="border-l-4 border-lime-300 pl-3">
-                            <p className="text-base font-bold text-black/80">{ex.danish}</p>
-                            <p className="text-xs text-black/60 mt-0.5">{ex.english}</p>
+                            <div className="text-base font-bold text-black/80">{ex.danish}</div>
+                            <div className="text-xs text-black/60 mt-0.5">{ex.english}</div>
                         </div>
                     ))}
                 </div>

--- a/app/language-learning/module/[moduleId]/grammar/components/ConceptCard.tsx
+++ b/app/language-learning/module/[moduleId]/grammar/components/ConceptCard.tsx
@@ -1,0 +1,49 @@
+import { MaskedSvgIcon } from '@/app/components/MaskedSvgIcon';
+import { GrammarConcept } from '@/api/TomeModuleAPI';
+
+/**
+ * Renders a single grammar concept card for the Grammar Introduction step (F04).
+ *
+ * Layout (per module-screens.jsx → GrammarIntro):
+ *   - Header row: lime circle (38px) with teacher icon + concept name as a heading
+ *   - Explanation paragraph
+ *   - 1–2 example rows: lime left-border, Danish text (bold) above English translation
+ *
+ * No card border — content is rendered inline (per 2026-06-09 change record).
+ */
+export function ConceptCard({ name, explanation, examples }: GrammarConcept) {
+    return (
+        <div className="flex flex-col">
+            {/* ── Header: icon circle + concept name ─────────────────────── */}
+            <div className="flex items-center gap-3 mb-4">
+                <div
+                    className="flex items-center justify-center flex-shrink-0 rounded-full bg-lime-200"
+                    style={{ width: 38, height: 38 }}
+                >
+                    <MaskedSvgIcon
+                        src="/images/teacher.svg"
+                        alt="Grammar concept"
+                        size="w-5 h-5"
+                        color="bg-cyan-800"
+                    />
+                </div>
+                <h2 className="text-lg font-bold text-black/80 leading-tight">{name}</h2>
+            </div>
+
+            {/* ── Explanation ─────────────────────────────────────────────── */}
+            <p className="text-sm text-black/80 leading-relaxed">{explanation}</p>
+
+            {/* ── Examples ────────────────────────────────────────────────── */}
+            {examples.length > 0 && (
+                <div className="flex flex-col gap-3 mt-4">
+                    {examples.map((ex, i) => (
+                        <div key={i} className="border-l-4 border-lime-300 pl-3">
+                            <p className="text-base font-bold text-black/80">{ex.danish}</p>
+                            <p className="text-xs text-black/60 mt-0.5">{ex.english}</p>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/language-learning/module/[moduleId]/grammar/page.tsx
+++ b/app/language-learning/module/[moduleId]/grammar/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useHeader } from '@/context/HeaderContext';
+import { RoundButton } from 'toto-react';
+import { TomeModuleAPI, GrammarConcept } from '@/api/TomeModuleAPI';
+import { TomeLearningDashboardAPI } from '@/api/TomeLearningDashboardAPI';
+import { TomePracticeSessionAPI } from '@/api/TomePracticeSessionAPI';
+import { SessionProgressBar } from '@/components/SessionProgressBar';
+import { ConceptCard } from './components/ConceptCard';
+
+// ─── Skeleton ────────────────────────────────────────────────────────────────
+
+function GrammarIntroSkeleton() {
+    return (
+        <div className="flex flex-col gap-4" aria-busy="true" aria-label="Loading grammar introduction">
+            {/* SessionBar */}
+            <div className="h-6 w-full rounded-full skeleton-shimmer" />
+            {/* Counter row */}
+            <div className="flex justify-between">
+                <div className="h-3 w-16 rounded-md skeleton-shimmer" />
+                <div className="h-3 w-10 rounded-md skeleton-shimmer" />
+            </div>
+            {/* Concept card */}
+            <div className="flex flex-col gap-3 mt-2">
+                <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-full skeleton-shimmer flex-shrink-0" />
+                    <div className="h-5 w-6/12 rounded-md skeleton-shimmer" />
+                </div>
+                <div className="h-4 w-full rounded-md skeleton-shimmer" />
+                <div className="h-4 w-10/12 rounded-md skeleton-shimmer" />
+                <div className="h-4 w-9/12 rounded-md skeleton-shimmer" />
+                <div className="flex flex-col gap-3 mt-2">
+                    {[0, 1].map((i) => (
+                        <div key={i} className="border-l-4 border-lime-200 pl-3 flex flex-col gap-1">
+                            <div className="h-4 w-7/12 rounded-md skeleton-shimmer" />
+                            <div className="h-3 w-5/12 rounded-md skeleton-shimmer" />
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+interface PageData {
+    concepts: GrammarConcept[];
+    userId: string;
+    moduleTitle: string;
+}
+
+export default function GrammarIntroPage() {
+    const params = useParams();
+    const router = useRouter();
+    const { setConfig } = useHeader();
+
+    const moduleId = params.moduleId as string;
+
+    // undefined = loading, null = error
+    const [data, setData] = useState<PageData | null | undefined>(undefined);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [isStartingSession, setIsStartingSession] = useState(false);
+
+    // ── Header ────────────────────────────────────────────────────────────────
+    useEffect(() => {
+        setConfig({
+            title: data?.moduleTitle ?? 'Grammar',
+            backButton: { enabled: true, onClick: () => router.back() },
+        });
+    }, [setConfig, router, data?.moduleTitle]);
+
+    // ── Load all data in parallel ─────────────────────────────────────────────
+    useEffect(() => {
+        Promise.all([
+            new TomeModuleAPI().getGrammarIntroduction(moduleId),
+            new TomeLearningDashboardAPI().getMe(),
+            new TomeModuleAPI().getModule(moduleId),
+        ]).then(([grammarIntro, me, module]) => {
+            setData({
+                concepts: grammarIntro.concepts,
+                userId: me.id,
+                moduleTitle: module.title,
+            });
+        }).catch(() => setData(null));
+    }, [moduleId]);
+
+    // ── Advance / exit ────────────────────────────────────────────────────────
+    const handleNext = async () => {
+        if (!data || isStartingSession) return;
+
+        const isLast = currentIndex === data.concepts.length - 1;
+
+        if (!isLast) {
+            setCurrentIndex((prev) => prev + 1);
+            return;
+        }
+
+        // Last concept — start the practice session and navigate into Practice
+        setIsStartingSession(true);
+        try {
+            await new TomePracticeSessionAPI().startPracticeSession(data.userId, moduleId);
+        } catch {
+            // On unexpected failure, still navigate — the practice page handles session load
+        } finally {
+            router.push(`/language-learning/module/${moduleId}/practice`);
+        }
+    };
+
+    // ── Render ────────────────────────────────────────────────────────────────
+    const concept = data?.concepts[currentIndex];
+    const total = data?.concepts.length ?? 0;
+
+    return (
+        <div className="flex flex-1 flex-col items-stretch md:self-center md:max-w-2xl md:w-full">
+
+            {/* ── Top bar: SessionBar + counter row ─────────────────────────── */}
+            <div className="px-5 pt-2">
+                {data && total > 0 ? (
+                    <>
+                        <SessionProgressBar total={total} mastered={currentIndex} deferred={0} />
+                        <div className="flex justify-between items-center mt-2">
+                            <span className="text-xs font-semibold uppercase tracking-widest text-black/50">
+                                Grammar
+                            </span>
+                            <span className="text-xs font-bold text-black/60">
+                                {currentIndex + 1} / {total}
+                            </span>
+                        </div>
+                    </>
+                ) : data === undefined ? (
+                    <>
+                        <div className="h-6 w-full rounded-full skeleton-shimmer" />
+                        <div className="flex justify-between mt-2">
+                            <div className="h-3 w-16 rounded-md skeleton-shimmer" />
+                            <div className="h-3 w-10 rounded-md skeleton-shimmer" />
+                        </div>
+                    </>
+                ) : null}
+            </div>
+
+            {/* ── Scrollable concept area ───────────────────────────────────── */}
+            <div className="flex flex-1 flex-col px-5 pt-4 pb-0 overflow-y-auto">
+
+                {data === undefined && <GrammarIntroSkeleton />}
+
+                {data === null && (
+                    <p className="text-sm text-cyan-600 mt-4">
+                        Failed to load grammar concepts. Please try again.
+                    </p>
+                )}
+
+                {data && concept && (
+                    <ConceptCard
+                        name={concept.name}
+                        explanation={concept.explanation}
+                        examples={concept.examples}
+                    />
+                )}
+
+                <div className="flex-1" />
+            </div>
+
+            {/* ── Next control ──────────────────────────────────────────────── */}
+            {data && (
+                <div className="flex justify-end px-5 py-4">
+                    <RoundButton
+                        svgIconPath={{ src: '/images/point-right.svg', alt: 'Next' }}
+                        type="primary"
+                        size="m"
+                        loading={isStartingSession}
+                        onClick={handleNext}
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/docs/features/04-grammar-introduction.md
+++ b/docs/features/04-grammar-introduction.md
@@ -1,5 +1,7 @@
 # Grammar Introduction — module step 1
 
+![Status](https://img.shields.io/badge/status-implemented-brightgreen?style=flat-square)
+
 ## 1. Purpose & Scope
 
 Delivers **Step 1 of the module flow**: a paged, purely instructional walkthrough
@@ -64,6 +66,7 @@ titled with the module name (e.g. "Who Are You?").
 | 2 | Load all concepts up front with a single call to `GET /modules/:moduleId/grammarIntroduction` and page client-side. | Content is small, pre-generated, already enriched and ordered server-side, and offline of AI (§5.1). |
 | 3 | On the last concept, do **not** navigate back to the overview or make a dedicated "grammar step complete" write — instead immediately call the practice-session-start endpoint (`POST /users/:userId/modules/:moduleId/practiceSessions`, owned by `05-practice-session`/F10) and enter Practice directly with the returned session. | Matches the actual backend contract: there is no Step-1-completion endpoint (F09's `GetGrammarIntroduction` is confirmed read-only), while starting a practice session is exactly what flips `UserModuleProgress` to `in_progress` (F10 business logic) — so triggering that start *is* the natural "completion" signal. It also removes the dead stop on the overview between Grammar and Practice. Supersedes the earlier "mark grammar-step completion" decision, which assumed a write the backend does not provide. |
 | 4 | `RoundButton` for the Next control (style guide). | Project convention. |
+| 5 | **`GET /me` is called in parallel with grammar data to obtain the `userId`** needed for `POST /users/:userId/modules/:moduleId/practiceSessions`. | The practice-session-start endpoint requires a userId in the URL path. The frontend derives this via `GET /me` (returns `{ id, email, cefrLevel, createdAt }`), fetched in parallel with the grammar intro data so there is no added latency. A 409 response from the practice-session-start call is handled gracefully — the user is routed to Practice regardless, where the existing session will be loaded. |
 
 ### 5.1. API Integrations
 

--- a/docs/features/04-grammar-introduction.md
+++ b/docs/features/04-grammar-introduction.md
@@ -39,14 +39,13 @@ titled with the module name (e.g. "Who Are You?").
 
 | Screen | Component Name | Description | Expected Behavior |
 |--------|----------------|-------------|-------------------|
-| Grammar intro | Step indicator (`StepDots`) | Top row showing the 3 module steps — Grammar (current) · Practice (upcoming) · Test (locked). | Marks Grammar as the active step. |
-| Grammar intro | Concept counter | "Concept n of N" label centered above the card. | Tracks position in the concept sequence. |
-| Grammar intro | Concept card | Bordered card: concept icon + concept name + short gloss (e.g. "Present tense — at være / 'to be' in the now"), the explanation paragraph, and 1–2 Danish examples each with an English translation (lime left-border). | Renders the concept's pre-generated `explanation` and examples; read-only. |
-| Grammar intro | Pager dots | Row of dots indicating concept count, with the current one elongated/highlighted. | Reflects current concept index. |
-| Grammar intro | Next control | Forward `RoundButton`. | Advances to the next concept. On the **last** concept: immediately starts the module's practice session (`POST /users/:userId/modules/:moduleId/practiceSessions`, owned by `05-practice-session`/F10 — §5.1) and routes the user straight into Practice with that session — no stop at the overview. |
+| Grammar intro | Session progress (`SessionBar`) | Segmented progress pill spanning the full width at the top of the screen body. `total` = number of grammar concepts in the module; `mastered` = count of concepts the user has advanced past (green segment); `deferred` = 0 (not applicable in this step). | Grows the green segment each time the user advances past a concept. |
+| Grammar intro | Concept counter | Split row immediately below `SessionBar`: a `Label` component reading "Grammar" (uppercase, left-aligned) and an "n / N" counter (e.g. "1 / 3") right-aligned. | Reflects the current concept index; updates each time the user advances. |
+| Grammar intro | Concept card | Inline layout — no card border. Header: a lime circle containing the teacher icon alongside the concept name as a heading. Below the header: the explanation paragraph. Below that: 1–2 Danish examples, each with an English translation (lime left-border). | Renders the concept's pre-generated `explanation` and examples; read-only. |
+| Grammar intro | Next control | Forward `RoundButton` (primary variant), right-aligned at the bottom of the screen. | Advances to the next concept. On the **last** concept: immediately starts the module's practice session (`POST /users/:userId/modules/:moduleId/practiceSessions`, owned by `05-practice-session`/F10 — §5.1) and routes the user straight into Practice with that session — no stop at the overview. |
 
 **Additional Notes:**
-- **Single concept module**: pager dots and counter collapse gracefully for N=1.
+- **Single concept module**: `SessionBar` shows total=1 and the counter reads "1 / 1"; both collapse gracefully.
 - Purely instructional — there is no answer input and nothing is scored here.
 - Navigation back to a previous concept (swipe/back) is a nice-to-have; forward via the Next control is the core path.
 
@@ -83,9 +82,8 @@ None — every component's backend need is covered by an existing, implemented e
 |---|-----------|-------|
 | 1 | Each concept renders its stored explanation + 1–2 examples, loaded in one call to `GET /modules/:moduleId/grammarIntroduction`. | §3.1.1; §5.1. |
 | 2 | The pager advances through all concepts and exits cleanly on the last. | — |
-| 3 | Step dots show Grammar as current, Practice upcoming, Test locked. | Read from `GET /me/progress` (owned by `03-module-overview`); this screen does not write that state directly. |
-| 4 | Completing the last concept immediately starts a practice session and routes the user straight into Practice with it — with no intermediate stop at the overview. | §4; §5.1; resolves Open Question 1. Replaces the earlier "finishing the step unlocks Practice on the overview" framing — see Technical Decision #3. |
-| 5 | No scoring or mastery change occurs in this step. | §3.1.1. |
+| 3 | Completing the last concept immediately starts a practice session and routes the user straight into Practice with it — with no intermediate stop at the overview. | §4; §5.1; resolves Open Question 1. Replaces the earlier "finishing the step unlocks Practice on the overview" framing — see Technical Decision #3. |
+| 4 | No scoring or mastery change occurs in this step. | §3.1.1. |
 
 ## 7. Open Questions
 

--- a/docs/features/changes/2026-06-09-grammar-intro-ui.md
+++ b/docs/features/changes/2026-06-09-grammar-intro-ui.md
@@ -1,0 +1,35 @@
+# Change: Grammar Intro — wireframe-aligned component update   (2026-06-09)
+
+## What changed
+
+- **Grammar Introduction (04-grammar-introduction)** — components revised to match the updated `module-screens.jsx` wireframe (`GrammarIntro`):
+  - `StepDots` (module steps indicator) replaced by `SessionBar` (concept-level progress pill).
+  - Pager dots row removed — `SessionBar` covers the "how far am I" role.
+  - Concept counter changed from a centered "Concept n of N" label to a split row: `Label` "Grammar" (left) + "n / N" counter (right), positioned below `SessionBar`.
+  - Concept card no longer has a bordered card wrapper; the short gloss line (e.g. "'to be' in the now") is removed — the concept name heading stands alone.
+  - Success Criterion #3 ("Step dots show Grammar as current…") removed; it referenced a component that no longer appears on this screen.
+
+## Why
+
+The wireframe (`module-screens.jsx` → `GrammarIntro`) was updated. The previous feature spec was based on an earlier design that used `StepDots` and pager dots. The new design uses `SessionBar` for within-step concept tracking, consistent with the approach used in exercise screens (`ExShell`). The 2026-06-08 idea change (practice loop / coverage guarantee) did not affect Grammar Intro semantics.
+
+## Impact (add / modify / remove)
+
+**Grammar Introduction screen:**
+
+- **Modify** — top indicator: replace `StepDots` (3-step module indicator) with `SessionBar` (segmented pill: green = concepts passed, remainder = not yet seen, deferred = 0).
+- **Modify** — concept counter: was a centered "Concept n of N" label; now a split row (`Label` "Grammar" left, "n / N" counter right) directly below `SessionBar`.
+- **Remove** — pager dots row (the row of elongated/highlighted dots below the concept card).
+- **Modify** — concept card: remove the outer card border; remove the short gloss subtitle under the concept name. Icon + name heading, explanation, and lime-bordered examples remain unchanged.
+
+## Behavior to verify
+
+- The `SessionBar` at the top shows the correct total (= number of concepts) and advances its green segment each time the user taps Next.
+- The "Grammar" label and "n / N" counter are rendered as a split row below the `SessionBar`, not centered above the concept card.
+- No pager dots appear anywhere on the Grammar Intro screen.
+- The concept card renders as an inline content area (no visible card border); the concept name appears as a heading directly next to the teacher icon, with no additional gloss line below it.
+- All other behavior (explanation text, lime-bordered examples, Next control, practice-session start on last concept) is unchanged.
+
+## Affected feature files
+
+- `docs/features/04-grammar-introduction.md`


### PR DESCRIPTION
## Summary

Implements Feature 04 — Grammar Introduction (Step 1 of the module execution flow).

### What this PR adds

- **Route** `/language-learning/module/[moduleId]/grammar` — a client-side paged walkthrough of the module's grammar concepts
- **API wrappers**:
  - `TomeModuleAPI.getGrammarIntroduction(moduleId)` — `GET /modules/:moduleId/grammarIntroduction`
  - `TomeLearningDashboardAPI.getMe()` — `GET /me` (fetches userId for user-scoped calls)
  - `TomePracticeSessionAPI.startPracticeSession(userId, moduleId)` — `POST /users/:userId/modules/:moduleId/practiceSessions`
- **`ConceptCard` component** — lime teacher-icon circle + concept name heading; explanation paragraph; lime left-bordered bilingual example pairs (no card border, per 2026-06-09 change record)
- **Grammar Introduction page** — `SessionProgressBar` (green grows on each advance) + split counter row (`GRAMMAR` label left, `n / N` right) + `ConceptCard` pager + right-aligned `RoundButton` Next control; on the last concept immediately starts the practice session and routes straight to `/practice`

### Behaviour

- All concepts are loaded in a single `GET /modules/:moduleId/grammarIntroduction` call at page load (read-only, no writes while paging)
- Paging is client-side; the `SessionProgressBar` and counter update on every advance
- On the last concept, the Next button calls `POST /users/:userId/modules/:moduleId/practiceSessions` (which also flips `UserModuleProgress` to `in_progress`) then navigates to Practice — no stop at the overview
- A 409 response (session already active) is handled gracefully: navigation proceeds to Practice regardless
- Skeleton loading state while data loads; error fallback if the calls fail

### Design reference

`docs/ui-design/tome-language-learning/module-screens.jsx` → `GrammarIntro()`

### Related

- Feature spec: `docs/features/04-grammar-introduction.md`
- Change record: `docs/features/changes/2026-06-09-grammar-intro-ui.md`

Closes #272
