### PR TITLE
Fix Multiple Choice shuffle: correct answer no longer always last (#282)

### DIFF
--- a/__tests__/seededShuffle.test.ts
+++ b/__tests__/seededShuffle.test.ts
@@ -6,7 +6,7 @@ import { seededShuffle } from '../utils/seededShuffle';
  * Runs `seededShuffle` over many distinct seeds and returns, for each index,
  * how many times the original first element ([0]) ended up at that index.
  */
-function distributionOfFirstElement(arr: number[], seeds: string[]): number[] {
+function distributionOfFirstElement<T>(arr: T[], seeds: string[]): number[] {
     const counts = new Array(arr.length).fill(0);
 
     for (const seed of seeds) {

--- a/__tests__/seededShuffle.test.ts
+++ b/__tests__/seededShuffle.test.ts
@@ -1,0 +1,83 @@
+import { seededShuffle } from '../utils/seededShuffle';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Runs `seededShuffle` over many distinct seeds and returns, for each index,
+ * how many times the original first element ([0]) ended up at that index.
+ */
+function distributionOfFirstElement(arr: number[], seeds: string[]): number[] {
+    const counts = new Array(arr.length).fill(0);
+
+    for (const seed of seeds) {
+        const shuffled = seededShuffle(arr, seed);
+        const pos = shuffled.indexOf(arr[0]);
+        counts[pos] += 1;
+    }
+
+    return counts;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('seededShuffle', () => {
+
+    it('is deterministic — the same seed always yields the same order', () => {
+        const arr = ['a', 'b', 'c', 'd'];
+
+        const first = seededShuffle(arr, 'exercise-123');
+        const second = seededShuffle(arr, 'exercise-123');
+
+        expect(second).toEqual(first);
+    });
+
+    it('does not mutate the input array', () => {
+        const arr = ['a', 'b', 'c', 'd'];
+
+        seededShuffle(arr, 'exercise-123');
+
+        expect(arr).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('returns a true permutation — same elements, none lost or duplicated', () => {
+        const arr = ['a', 'b', 'c', 'd'];
+
+        const shuffled = seededShuffle(arr, 'some-seed');
+
+        expect([...shuffled].sort()).toEqual([...arr].sort());
+    });
+
+    it('does NOT always push the first element to the last position (the bug)', () => {
+        const arr = ['answer', 'd1', 'd2', 'd3'];
+        const seeds = Array.from({ length: 200 }, (_, i) => `exercise-${i}`);
+
+        const counts = distributionOfFirstElement(arr, seeds);
+
+        // The buggy implementation always placed [0] at the last index.
+        // The correct answer must be able to land anywhere, so the last index
+        // must not capture every single run.
+        expect(counts[arr.length - 1]).toBeLessThan(seeds.length);
+    });
+
+    it('places the first element in every position across many seeds (roughly uniform)', () => {
+        const arr = ['answer', 'd1', 'd2', 'd3'];
+        const seeds = Array.from({ length: 400 }, (_, i) => `exercise-${i}`);
+
+        const counts = distributionOfFirstElement(arr, seeds);
+
+        // Every position should be reached at least once...
+        for (const count of counts) {
+            expect(count).toBeGreaterThan(0);
+        }
+
+        // ...and no position should dominate (uniform would be 25%; allow slack).
+        for (const count of counts) {
+            expect(count).toBeLessThan(seeds.length * 0.45);
+        }
+    });
+
+    it('handles edge cases — empty and single-element arrays', () => {
+        expect(seededShuffle([], 'seed')).toEqual([]);
+        expect(seededShuffle(['only'], 'seed')).toEqual(['only']);
+    });
+});

--- a/app/language-learning/module/[moduleId]/practice/components/ExMultipleChoice.tsx
+++ b/app/language-learning/module/[moduleId]/practice/components/ExMultipleChoice.tsx
@@ -3,18 +3,9 @@ import { Exercise } from '@/api/TomePracticeSessionAPI';
 import { SubmissionState } from '../types';
 import { CheckFooter } from './CheckFooter';
 import { MaskedSvgIcon } from '@/app/components/MaskedSvgIcon';
+import { seededShuffle } from '@/utils/seededShuffle';
 
 const KEYS = ['A', 'B', 'C', 'D'] as const;
-
-function seededShuffle<T>(arr: T[], seed: string): T[] {
-    const hash = seed.split('').reduce((acc, c, i) => acc + c.charCodeAt(0) * (i + 1), 0);
-    const copy = [...arr];
-    for (let i = copy.length - 1; i > 0; i--) {
-        const j = (hash * (i + 1)) % (i + 1);
-        [copy[i], copy[j]] = [copy[j], copy[i]];
-    }
-    return copy;
-}
 
 interface ExMultipleChoiceProps {
     exercise: Exercise;

--- a/docs/features/05-practice-session.md
+++ b/docs/features/05-practice-session.md
@@ -71,7 +71,7 @@ Participates in journey **J4** (practise a module).
 |--------|----------------|-------------|-------------------|
 | Practice | Session bar (`SessionBar`) | Top progress bar segmented into mastered / remaining / deferred, with an "n / total" counter. | Advances as the user completes exercises in the session. |
 | Practice | Instruction label | Per-exercise instruction (e.g. "Choose the correct word", "Arrange the words"). | Reflects the current exercise type. |
-| Practice | Exercise body — Multiple Choice | Sentence with a blank + 4 lettered options (A–D); one selectable. | Receptive recognition; select → enables Check. |
+| Practice | Exercise body — Multiple Choice | Sentence with a blank + 4 lettered options (A–D); one selectable. Option order is **shuffled** so the correct answer can appear in any position (seeded deterministically per `exercise.id` via `utils/seededShuffle`, so order is stable across re-renders). | Receptive recognition; select → enables Check. |
 | Practice | Exercise body — Sentence Reorder | A build area + a word bank of draggable/tappable tiles. | User arranges all provided words; Check enabled when filled. |
 | Practice | Exercise body — Fill in the Blank | Sentence with an inline text input for the missing word/form; optional "Hint" chip. | Controlled production; typed answer submitted via Send. |
 | Practice | Exercise body — Conjugation Drill | Verb chip (infinitive + gloss), subject → present-tense input box. | Targeted production of a verb form; submitted via Send. |

--- a/utils/seededShuffle.ts
+++ b/utils/seededShuffle.ts
@@ -1,0 +1,78 @@
+/**
+ * Deterministically shuffles an array using a seeded Fisher–Yates algorithm.
+ *
+ * The shuffle is fully determined by the seed: the same array and seed always
+ * produce the same ordering. This keeps option ordering stable across re-renders
+ * within a session (no flicker) while still distributing elements across all
+ * positions roughly uniformly over many different seeds.
+ *
+ * Implementation notes:
+ * - A 32-bit hash is derived from the seed string (FNV-style mixing).
+ * - The hash drives a mulberry32 PRNG, which yields a fresh pseudo-random value
+ *   on each iteration. This is what the previous implementation lacked: it used
+ *   `(hash * (i + 1)) % (i + 1)`, which is always `0`, so the swap target never
+ *   varied and element 0 was deterministically pushed to the last position.
+ *
+ * @param {T[]} arr - The array to shuffle. It is not mutated; a copy is returned.
+ * @param {string} seed - The seed driving the deterministic shuffle.
+ *
+ * @returns {T[]} A new array containing the same elements in a shuffled order.
+ */
+export function seededShuffle<T>(arr: T[], seed: string): T[] {
+
+    const copy = [...arr];
+    const random = mulberry32(hashSeed(seed));
+
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(random() * (i + 1));
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+
+    return copy;
+}
+
+/**
+ * Derives a 32-bit unsigned integer hash from a seed string.
+ *
+ * Uses the FNV-1a mixing approach so that small changes in the seed (e.g.
+ * consecutive exercise ids) produce well-spread hash values.
+ *
+ * @param {string} seed - The seed string to hash.
+ *
+ * @returns {number} A 32-bit unsigned integer hash.
+ */
+function hashSeed(seed: string): number {
+
+    let hash = 2166136261;
+
+    for (let i = 0; i < seed.length; i++) {
+        hash ^= seed.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+
+    return hash >>> 0;
+}
+
+/**
+ * mulberry32 PRNG: a small, fast 32-bit pseudo-random number generator.
+ *
+ * Returns a function that, on each call, produces the next pseudo-random number
+ * in [0, 1) derived deterministically from the initial state.
+ *
+ * @param {number} state - The initial 32-bit state (the seed hash).
+ *
+ * @returns {() => number} A function yielding the next pseudo-random number in [0, 1).
+ */
+function mulberry32(state: number): () => number {
+
+    return function () {
+
+        state |= 0;
+        state = (state + 0x6d2b79f5) | 0;
+
+        let t = Math.imul(state ^ (state >>> 15), 1 | state);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}


### PR DESCRIPTION
## Summary

Fixes #282 — the Multiple Choice exercise always rendered the correct answer in the last position (option D), letting users answer correctly without reading the prompt and corrupting mastery scoring in both practice and the module test.

## Root cause

`seededShuffle` in `ExMultipleChoice.tsx` computed:

```ts
const j = (hash * (i + 1)) % (i + 1);   // always 0
```

`hash * (i + 1)` is by definition a multiple of `(i + 1)`, so `j` was always `0`. The loop just pushed element `0` (the correct answer, built as `[exercise.answer, ...distractors]`) to the last position every time.

## Fix

- Extracted the shuffle into `utils/seededShuffle.ts` as a proper **seeded Fisher–Yates** (FNV-1a seed hash + mulberry32 PRNG), so `j` is a real `0 ≤ j ≤ i` per iteration.
- Kept it **seeded/deterministic per `exercise.id`** so option order is stable across re-renders (no flicker) — `correctKey` derivation is unchanged.
- Wired the util into `ExMultipleChoice.tsx`, removing the buggy inline version.
- This automatically covers the **module test**, which reuses the same component.

## Tests

New `__tests__/seededShuffle.test.ts` (TDD):
- determinism per seed, no input mutation, true permutation (no lost/duplicated elements)
- bug reproduction: the correct answer is **not** always last
- roughly-uniform position distribution across many seeds (every position reached, none dominating)
- empty / single-element edge cases

Verification: `tsc --noEmit` clean, ESLint clean, full Jest suite green (49/49), `npm run build` compiles successfully.

## Docs

Updated `docs/features/05-practice-session.md` §Components to note MC options are shuffled (seeded per `exercise.id`).

## Out of scope (per issue)

Distractor generation, number of options, other exercise types, and result/feedback UI are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)