### PR TITLE
fix(#292): update weekly stats to rolling 7-day window via F24 endpoint

### DIFF
--- a/__tests__/TomeLearningDashboardAPI.test.ts
+++ b/__tests__/TomeLearningDashboardAPI.test.ts
@@ -1,0 +1,53 @@
+import moment from 'moment';
+import { TomeLearningDashboardAPI } from '../api/TomeLearningDashboardAPI';
+import { TotoAPI } from '../api/TotoAPI';
+
+jest.mock('../api/TotoAPI');
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+
+function fakeResponse(body: unknown) {
+    return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+beforeEach(() => {
+    mockFetch.mockReset();
+    (TotoAPI as unknown as jest.Mock).mockImplementation(() => ({ fetch: mockFetch }));
+});
+
+// ─── getWeeklySessionStats ──────────────────────────────────────────────────────
+
+describe('TomeLearningDashboardAPI.getWeeklySessionStats', () => {
+
+    it('calls GET /me/stats/dailyActivity with from = today minus 6 days', async () => {
+        const expectedFrom = moment().subtract(6, 'days').format('YYYYMMDD');
+        mockFetch.mockResolvedValue(fakeResponse({ from: expectedFrom, to: moment().format('YYYYMMDD'), days: [] }));
+
+        const api = new TomeLearningDashboardAPI();
+        await api.getWeeklySessionStats();
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            'tome-ms-language',
+            `/me/stats/dailyActivity?from=${expectedFrom}`,
+        );
+    });
+
+    it('does NOT use Monday of the current ISO week as from', async () => {
+        const monday = moment().startOf('isoWeek').format('YYYYMMDD');
+        const rollingStart = moment().subtract(6, 'days').format('YYYYMMDD');
+        mockFetch.mockResolvedValue(fakeResponse({ from: rollingStart, to: moment().format('YYYYMMDD'), days: [] }));
+
+        const api = new TomeLearningDashboardAPI();
+        await api.getWeeklySessionStats();
+
+        const calledPath: string = mockFetch.mock.calls[0][1];
+
+        // On any day other than Monday the two differ; the endpoint must use the rolling start
+        if (monday !== rollingStart) {
+            expect(calledPath).not.toContain(monday);
+        }
+        expect(calledPath).toContain(rollingStart);
+    });
+});

--- a/api/TomeLearningDashboardAPI.ts
+++ b/api/TomeLearningDashboardAPI.ts
@@ -6,9 +6,9 @@ import { TotoAPI } from "./TotoAPI";
  * Wraps the tome-ms-language backend.
  *
  * Endpoint mapping (basepath handled by NEXT_PUBLIC_TOME_LANGUAGE_API_ENDPOINT):
- *   - GET /me                    → user profile (id, email, cefrLevel)
+ *   - GET /me                        → user profile (id, email, cefrLevel)
  *   - GET /me/progress               → level info + modules at current level
- *   - GET /sessions/stats/weekly     → session counts per day for current week
+ *   - GET /me/stats/dailyActivity    → per-day activity counts for rolling 7-day window
  */
 export class TomeLearningDashboardAPI {
 
@@ -37,15 +37,14 @@ export class TomeLearningDashboardAPI {
     }
 
     /**
-     * Fetches completed session counts per day for the current calendar week (Mon–Sun).
-     * Computes the Monday of the current week and passes it as the required `from` param.
+     * Fetches per-day activity counts for the rolling 7-day window ending today
+     * (last 6 days + today). Computes `from` as today − 6 days.
      *
-     * Endpoint: GET /sessions/stats/weekly?from=YYYYMMDD
-     * `from` must be a Monday in YYYYMMDD format.
+     * Endpoint: GET /me/stats/dailyActivity?from=YYYYMMDD
      */
     async getWeeklySessionStats(): Promise<WeeklySessionStatsResponse> {
-        const from = getMondayOfCurrentWeek();
-        return (await new TotoAPI().fetch('tome-ms-language', `/sessions/stats/weekly?from=${from}`)).json();
+        const from = getRollingWindowStart();
+        return (await new TotoAPI().fetch('tome-ms-language', `/me/stats/dailyActivity?from=${from}`)).json();
     }
 }
 
@@ -92,15 +91,23 @@ export interface ModuleProgressEntry {
 }
 
 export interface WeeklySessionStatsResponse {
-    /** Seven entries, Mon → Sun, with date (YYYYMMDD) and completed-session count. */
-    days: WeeklyStatDay[];
+    /** First day of the 7-day window in YYYYMMDD format (= today − 6). */
+    from: string;
+    /** Last day of the window in YYYYMMDD format (= today). */
+    to: string;
+    /** Seven entries, oldest → today, one per day in the rolling window. */
+    days: DailyActivityDay[];
 }
 
-export interface WeeklyStatDay {
+export interface DailyActivityDay {
     /** Date in YYYYMMDD format */
     date: string;
-    /** Number of sessions completed on this day */
-    count: number;
+    /** Completed practice sessions on this day */
+    practiceSessions: number;
+    /** Passed module tests on this day */
+    successfulModuleTests: number;
+    /** Passed level tests on this day */
+    successfulLevelTests: number;
 }
 
 // ─── Frontend-facing derived types (built from the raw API data) ───────────
@@ -134,11 +141,11 @@ export interface CurrentModuleInfo {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Returns the Monday of the current calendar week in YYYYMMDD format.
- * Required by GET /sessions/stats/weekly.
+ * Returns the start of the rolling 7-day window (today − 6 days) in YYYYMMDD format.
+ * Used as `from` for GET /me/stats/dailyActivity so the window ends on today.
  */
-function getMondayOfCurrentWeek(): string {
-    return moment().startOf('isoWeek').format('YYYYMMDD');
+function getRollingWindowStart(): string {
+    return moment().subtract(6, 'days').format('YYYYMMDD');
 }
 
 /**

--- a/app/language-learning/components/WeeklyModuleStats.tsx
+++ b/app/language-learning/components/WeeklyModuleStats.tsx
@@ -50,12 +50,12 @@ export function WeeklyModuleStats({ loading, days }: WeeklyModuleStatsProps) {
     const maxCount = Math.max(...days.map((d) => d.practiceSessions), 1);
 
     return (
-        <div>
+        <div className="flex-1 flex flex-col items-stretch">
             <p className="text-[11px] font-semibold tracking-[0.2em] uppercase text-white/80 mb-3">
                 This week
             </p>
 
-            <div className="flex items-end gap-2" style={{ height: 110 }}>
+            <div className="flex flex-1 items-end gap-2" style={{ height: 110 }}>
                 {days.map((day) => {
                     const isToday = day.date === today;
                     const barHeight = day.practiceSessions > 0

--- a/app/language-learning/components/WeeklyModuleStats.tsx
+++ b/app/language-learning/components/WeeklyModuleStats.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import moment from 'moment';
-import { WeeklyStatDay } from '@/api/TomeLearningDashboardAPI';
+import { DailyActivityDay } from '@/api/TomeLearningDashboardAPI';
 
 interface WeeklyModuleStatsProps {
     loading?: boolean;
-    /** Seven entries for Mon–Sun; days with no sessions have count: 0. */
-    days?: WeeklyStatDay[];
+    /** Seven entries for the rolling 7-day window (oldest → today); days with no sessions have practiceSessions: 0. */
+    days?: DailyActivityDay[];
 }
 
 /**
- * 7-day bar chart (Mon–Sun) showing sessions completed per day.
+ * 7-day bar chart showing practice sessions completed per day over a rolling window (oldest → today).
  * Handles its own loading (skeleton) and empty states via props.
  * Day labels are derived from the date field.
  * Today's bar is highlighted with lime-200 accent.
@@ -40,14 +40,14 @@ export function WeeklyModuleStats({ loading, days }: WeeklyModuleStatsProps) {
                     This week
                 </p>
                 <div className="flex items-center justify-center text-sm text-white/50" style={{ height: 110 }}>
-                    No activity yet this week
+                    No activity in the last 7 days
                 </div>
             </div>
         );
     }
 
     const today = moment().format('YYYYMMDD');
-    const maxCount = Math.max(...days.map((d) => d.count), 1);
+    const maxCount = Math.max(...days.map((d) => d.practiceSessions), 1);
 
     return (
         <div>
@@ -58,23 +58,23 @@ export function WeeklyModuleStats({ loading, days }: WeeklyModuleStatsProps) {
             <div className="flex items-end gap-2" style={{ height: 110 }}>
                 {days.map((day) => {
                     const isToday = day.date === today;
-                    const barHeight = day.count > 0
-                        ? Math.max((day.count / maxCount) * 84, 8)
+                    const barHeight = day.practiceSessions > 0
+                        ? Math.max((day.practiceSessions / maxCount) * 84, 8)
                         : 2;
                     const dayLabel = moment(day.date, 'YYYYMMDD').format('dd').charAt(0);
 
                     return (
                         <div key={day.date} className="flex-1 flex flex-col items-center justify-end" style={{ height: '100%' }}>
-                            {day.count > 0 && (
+                            {day.practiceSessions > 0 && (
                                 <span className={`text-[10px] font-bold mb-1 ${isToday ? 'text-lime-200' : 'text-cyan-200'}`} aria-hidden="true">
-                                    {day.count}
+                                    {day.practiceSessions}
                                 </span>
                             )}
                             <div
-                                className={`w-full rounded-sm ${isToday ? 'bg-lime-200' : day.count > 0 ? 'bg-cyan-800' : 'bg-cyan-800/40'}`}
+                                className={`w-full rounded-sm ${isToday ? 'bg-lime-200' : day.practiceSessions > 0 ? 'bg-cyan-800' : 'bg-cyan-800/40'}`}
                                 style={{ height: barHeight }}
                                 role="img"
-                                aria-label={`${dayLabel}: ${day.count} session${day.count !== 1 ? 's' : ''} completed`}
+                                aria-label={`${dayLabel}: ${day.practiceSessions} session${day.practiceSessions !== 1 ? 's' : ''} completed`}
                             />
                             <span className={`text-[10px] mt-1.5 ${isToday ? 'text-lime-200 font-bold' : 'text-white/85'}`}>
                                 {dayLabel}

--- a/app/language-learning/page.tsx
+++ b/app/language-learning/page.tsx
@@ -7,7 +7,7 @@ import { RoundButton } from 'toto-react';
 import {
     TomeLearningDashboardAPI,
     MeProgressResponse,
-    WeeklyStatDay,
+    DailyActivityDay,
     CEFR_LEVEL_NAMES,
     CefrLevel,
     deriveCurrentModule,
@@ -24,7 +24,7 @@ export default function LanguageLearningHomePage() {
     const router = useRouter();
 
     const [progress, setProgress] = useState<MeProgressResponse | null | undefined>(undefined);
-    const [weeklyStats, setWeeklyStats] = useState<WeeklyStatDay[] | null | undefined>(undefined);
+    const [weeklyStats, setWeeklyStats] = useState<DailyActivityDay[] | null | undefined>(undefined);
 
     useEffect(() => {
         setConfig({
@@ -47,8 +47,8 @@ export default function LanguageLearningHomePage() {
     const currentLevelSummary = progress?.levels.find((l) => l.status === 'current');
     const currentModule = progress ? deriveCurrentModule(progress) : undefined;
 
-    const weekTotal = weeklyStats?.reduce((a, d) => a + d.count, 0) ?? 0;
-    const activeDays = weeklyStats?.filter((d) => d.count > 0).length ?? 0;
+    const weekTotal = weeklyStats?.reduce((a, d) => a + d.practiceSessions, 0) ?? 0;
+    const activeDays = weeklyStats?.filter((d) => d.practiceSessions > 0).length ?? 0;
     const currentModuleProgress = progress?.modules.find((m) => m.status === 'in_progress');
     const wordsSeen = currentModuleProgress?.vocabularyItemsPracticedCount ?? 0;
 

--- a/docs/features/01-home-dashboard.md
+++ b/docs/features/01-home-dashboard.md
@@ -74,7 +74,7 @@ browse the level).
 | Component or Screen | API Integration | Description |
 | ------------------- | --------------- | ----------- |
 | Level track, Continue CTA | `GET /me/progress` (`tome-ms-language`, via `TomeLearningDashboardAPI.getMeProgress`) | Returns the user's current CEFR level, a status summary for all 6 levels, and the per-module status list for the current level. Drives the level track, the module-dot progress, and (via `deriveCurrentModule`) the Continue CTA's target module. |
-| Weekly stats | `GET /sessions/stats/weekly?from=YYYYMMDD` (`tome-ms-language`, via `TomeLearningDashboardAPI.getWeeklySessionStats`) | Returns completed practice-session counts per day for the **rolling 7-day window ending today**; `from` is computed client-side as **today − 6 days** (YYYYMMDD). Returns 7 entries, oldest day → today. Drives the 7-day bar chart. |
+| Weekly stats | `GET /me/stats/dailyActivity?from=YYYYMMDD` (`tome-ms-language`, via `TomeLearningDashboardAPI.getWeeklySessionStats`) | Returns per-day activity counts for the **rolling 7-day window ending today** (F24). `from` is computed client-side as **today − 6 days** (YYYYMMDD). Response shape: `{ from, to, days: [{ date, practiceSessions, successfulModuleTests, successfulLevelTests }] }`, 7 entries oldest → today. The bar chart consumes `practiceSessions`; the other counts are available for future widgets. |
 
 ## 6. Success Criteria
 


### PR DESCRIPTION
## Summary

- Switches `getWeeklySessionStats()` from the old `GET /sessions/stats/weekly` (non-existent) to the new `GET /me/stats/dailyActivity?from=YYYYMMDD` endpoint delivered by `tome-ms-language` F24.
- Replaces `getMondayOfCurrentWeek()` with `getRollingWindowStart()` — `from` is now **today − 6 days** (rolling window), not the Monday of the current ISO week.
- Renames `WeeklyStatDay` → `DailyActivityDay` and replaces the `count` field with `practiceSessions` / `successfulModuleTests` / `successfulLevelTests` to match the F24 response shape.
- Cascades the type rename into `WeeklyModuleStats.tsx` (all `day.count` → `day.practiceSessions`) and `page.tsx` (`weekTotal`, `activeDays`).
- Updates empty-state copy from "No activity yet this week" → "No activity in the last 7 days".
- Updates `docs/features/01-home-dashboard.md` API integrations table to reference the new F24 endpoint and response shape.
- Adds unit tests verifying the correct endpoint path and `from` computation.

## Test plan

- [x] `npx jest` — 73 tests pass (including 2 new tests for `TomeLearningDashboardAPI.getWeeklySessionStats`)
- [x] `npx tsc --noEmit` — clean compile, no type errors
- [x] `npm run build` — production build succeeds

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyroFMozLoBjUYgqHXEvau