### PR TITLE
Stack module tests and level tests into the weekly stats bar chart

### DIFF
--- a/__tests__/weeklyBarStack.test.ts
+++ b/__tests__/weeklyBarStack.test.ts
@@ -1,0 +1,78 @@
+import { computeWeeklyBarStacks } from '../utils/weeklyBarStack';
+import { DailyActivityDay } from '../api/TomeLearningDashboardAPI';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function day(date: string, practiceSessions: number, successfulModuleTests: number, successfulLevelTests: number): DailyActivityDay {
+    return { date, practiceSessions, successfulModuleTests, successfulLevelTests };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('computeWeeklyBarStacks', () => {
+
+    it('proportionally splits a mixed day\'s bar height across all three segments', () => {
+        const days = [
+            day('20260706', 4, 2, 2),
+            day('20260707', 1, 0, 0),
+        ];
+
+        const [mixed] = computeWeeklyBarStacks(days);
+
+        expect(mixed.total).toBe(8);
+        expect(mixed.practiceHeight).toBeCloseTo(mixed.barHeight * (4 / 8));
+        expect(mixed.moduleTestHeight).toBeCloseTo(mixed.barHeight * (2 / 8));
+        expect(mixed.levelTestHeight).toBeCloseTo(mixed.barHeight * (2 / 8));
+        expect(mixed.practiceHeight + mixed.moduleTestHeight + mixed.levelTestHeight).toBeCloseTo(mixed.barHeight);
+    });
+
+    it('gives a zero-height practice segment (no sliver) when a day has only test successes', () => {
+        const days = [
+            day('20260706', 0, 3, 1),
+        ];
+
+        const [result] = computeWeeklyBarStacks(days);
+
+        expect(result.total).toBe(4);
+        expect(result.practiceHeight).toBe(0);
+        expect(result.moduleTestHeight).toBeGreaterThan(0);
+        expect(result.levelTestHeight).toBeGreaterThan(0);
+    });
+
+    it('reports zero total and zero segment heights for a fully empty day', () => {
+        const days = [
+            day('20260706', 0, 0, 0),
+        ];
+
+        const [result] = computeWeeklyBarStacks(days);
+
+        expect(result.total).toBe(0);
+        expect(result.barHeight).toBe(0);
+        expect(result.practiceHeight).toBe(0);
+        expect(result.moduleTestHeight).toBe(0);
+        expect(result.levelTestHeight).toBe(0);
+    });
+
+    it('gives the day with the highest total the max bar height, and roughly halves it for a day at half the total', () => {
+        const days = [
+            day('20260701', 10, 0, 0),
+            day('20260702', 5, 0, 0),
+        ];
+
+        const [maxDay, halfDay] = computeWeeklyBarStacks(days);
+
+        expect(maxDay.barHeight).toBe(84);
+        expect(halfDay.barHeight).toBeCloseTo(42);
+    });
+
+    it('applies the minimum bar height floor to a low-total day in a high-total window', () => {
+        const days = [
+            day('20260701', 100, 0, 0),
+            day('20260702', 1, 0, 0),
+        ];
+
+        const [, lowDay] = computeWeeklyBarStacks(days);
+
+        expect(lowDay.barHeight).toBe(8);
+    });
+});

--- a/app/language-learning/components/WeeklyModuleStats.tsx
+++ b/app/language-learning/components/WeeklyModuleStats.tsx
@@ -2,6 +2,7 @@
 
 import moment from 'moment';
 import { DailyActivityDay } from '@/api/TomeLearningDashboardAPI';
+import { computeWeeklyBarStacks } from '@/utils/weeklyBarStack';
 
 interface WeeklyModuleStatsProps {
     loading?: boolean;
@@ -10,10 +11,12 @@ interface WeeklyModuleStatsProps {
 }
 
 /**
- * 7-day bar chart showing practice sessions completed per day over a rolling window (oldest → today).
+ * 7-day stacked bar chart over a rolling window (oldest → today): each bar stacks
+ * practice sessions (bottom), module tests passed (middle) and level tests passed
+ * (top), sized to the day's share of activity relative to the busiest day in the window.
  * Handles its own loading (skeleton) and empty states via props.
  * Day labels are derived from the date field.
- * Today's bar is highlighted with lime-200 accent.
+ * Today's bar is highlighted with a lime accent.
  */
 export function WeeklyModuleStats({ loading, days }: WeeklyModuleStatsProps) {
 
@@ -47,7 +50,7 @@ export function WeeklyModuleStats({ loading, days }: WeeklyModuleStatsProps) {
     }
 
     const today = moment().format('YYYYMMDD');
-    const maxCount = Math.max(...days.map((d) => d.practiceSessions), 1);
+    const stacks = computeWeeklyBarStacks(days);
 
     return (
         <div className="flex-1 flex flex-col items-stretch">
@@ -56,26 +59,51 @@ export function WeeklyModuleStats({ loading, days }: WeeklyModuleStatsProps) {
             </p>
 
             <div className="flex flex-1 items-end gap-2" style={{ height: 110 }}>
-                {days.map((day) => {
+                {days.map((day, i) => {
                     const isToday = day.date === today;
-                    const barHeight = day.practiceSessions > 0
-                        ? Math.max((day.practiceSessions / maxCount) * 84, 8)
-                        : 2;
+                    const stack = stacks[i];
                     const dayLabel = moment(day.date, 'YYYYMMDD').format('dd').charAt(0);
+                    const ariaLabel = `${dayLabel}: ${stack.total} activit${stack.total !== 1 ? 'ies' : 'y'} `
+                        + `(${day.practiceSessions} practice session${day.practiceSessions !== 1 ? 's' : ''}, `
+                        + `${day.successfulModuleTests} module test${day.successfulModuleTests !== 1 ? 's' : ''}, `
+                        + `${day.successfulLevelTests} level test${day.successfulLevelTests !== 1 ? 's' : ''})`;
 
                     return (
                         <div key={day.date} className="flex-1 flex flex-col items-center justify-end" style={{ height: '100%' }}>
-                            {day.practiceSessions > 0 && (
+                            {stack.total > 0 && (
                                 <span className={`text-[10px] font-bold mb-1 ${isToday ? 'text-lime-200' : 'text-cyan-200'}`} aria-hidden="true">
-                                    {day.practiceSessions}
+                                    {stack.total}
                                 </span>
                             )}
-                            <div
-                                className={`w-full rounded-sm ${isToday ? 'bg-lime-200' : day.practiceSessions > 0 ? 'bg-cyan-800' : 'bg-cyan-800/40'}`}
-                                style={{ height: barHeight }}
-                                role="img"
-                                aria-label={`${dayLabel}: ${day.practiceSessions} session${day.practiceSessions !== 1 ? 's' : ''} completed`}
-                            />
+                            {stack.total > 0 ? (
+                                <div className="w-full flex flex-col justify-end" role="img" aria-label={ariaLabel} style={{ height: stack.barHeight }}>
+                                    {stack.levelTestHeight > 0 && (
+                                        <div
+                                            className={`w-full ${isToday ? 'bg-lime-400' : 'bg-cyan-400'} ${stack.moduleTestHeight === 0 && stack.practiceHeight === 0 ? 'rounded-sm' : 'rounded-t-sm'}`}
+                                            style={{ height: stack.levelTestHeight }}
+                                        />
+                                    )}
+                                    {stack.moduleTestHeight > 0 && (
+                                        <div
+                                            className={`w-full ${isToday ? 'bg-lime-300' : 'bg-cyan-600'} ${stack.levelTestHeight === 0 && stack.practiceHeight === 0 ? 'rounded-sm' : stack.levelTestHeight === 0 ? 'rounded-t-sm' : stack.practiceHeight === 0 ? 'rounded-b-sm' : ''}`}
+                                            style={{ height: stack.moduleTestHeight }}
+                                        />
+                                    )}
+                                    {stack.practiceHeight > 0 && (
+                                        <div
+                                            className={`w-full ${isToday ? 'bg-lime-200' : 'bg-cyan-800'} ${stack.moduleTestHeight === 0 && stack.levelTestHeight === 0 ? 'rounded-sm' : 'rounded-b-sm'}`}
+                                            style={{ height: stack.practiceHeight }}
+                                        />
+                                    )}
+                                </div>
+                            ) : (
+                                <div
+                                    className="w-full rounded-sm bg-cyan-800/40"
+                                    style={{ height: 2 }}
+                                    role="img"
+                                    aria-label={`${dayLabel}: no activity`}
+                                />
+                            )}
                             <span className={`text-[10px] mt-1.5 ${isToday ? 'text-lime-200 font-bold' : 'text-white/85'}`}>
                                 {dayLabel}
                             </span>

--- a/docs/features/01-home-dashboard.md
+++ b/docs/features/01-home-dashboard.md
@@ -41,7 +41,7 @@ browse the level).
 | Home dashboard | Level track | Horizontal A1→A2→B1→B2→C1→C2 row of nodes with connectors; current level enlarged + lime-filled, completed levels filled, future levels outlined. Below: level name ("Foundation") + a row of module dots for the current level. | Highlights the user's current level; module dots fill as modules complete. Static (not a navigation control in v2.0). |
 | Home dashboard | Continue CTA | Dark rounded card with a lime circular arrow, kicker "Continue · A1·01", and the current module title. | Tapping navigates to the current module (Module overview, or its current step). Hidden/replaced with an empty state when no module is in progress. |
 | Home dashboard | Primary nav row | Two `RoundButton`s (primary variant) with labels: **Modules**, **Analyze**. The third button (Sources/Knowledge) is **not rendered** in v2.0. | Modules → Module map (`02`). Analyze → Analyze Content (**skipped**). |
-| Home dashboard | Weekly stats | "This week" label + a 7-day bar chart over a **rolling window** (the last 6 days + today) of practice sessions completed per day. | Renders one bar per day (oldest → today); height = practice sessions completed that day; today emphasised. |
+| Home dashboard | Weekly stats | "This week" label + a 7-day **stacked** bar chart over a **rolling window** (the last 6 days + today) of practice sessions, module tests passed, and level tests passed per day. | Renders one stacked bar per day (oldest → today): practice sessions (bottom), successful module tests (middle), successful level tests (top), each in a shade of the bar color; bar height = day's total of all three, normalized against the busiest day in the window; today emphasised. |
 | Home dashboard | Screen chrome | `TomeScreen` titled "Language Learning". | Standard app header; layout shell, not a separate feature. |
 
 **Additional Notes:**
@@ -55,7 +55,7 @@ browse the level).
 - The level track marks levels < current as completed, the current level as active, and levels > current as future.
 - Module-dots / "x / N modules" reflect **UserModuleProgress** for the current level: count of `completed` modules out of the level's total.
 - The **current module** for the Continue CTA = the user's `in_progress` module; if none is in progress, the first `available` (not-yet-completed, unlocked) module at the current level.
-- Weekly stats show **completed practice sessions per day** over a **rolling 7-day window** — the last 6 days plus today — **not** a fixed calendar week (Mon–Sun); each bar height = count of practice sessions the user completed on that day. The window always ends on today, so the chart shows the user's most recent week of activity regardless of which weekday it is.
+- Weekly stats show **completed practice sessions, passed module tests, and passed level tests per day**, stacked into one bar per day, over a **rolling 7-day window** — the last 6 days plus today — **not** a fixed calendar week (Mon–Sun); each bar's total height = the sum of the three counts for that day, normalized against the busiest day in the window. The window always ends on today, so the chart shows the user's most recent week of activity regardless of which weekday it is.
 - The dashboard is **read-only** with respect to progress — it never mutates mastery or module state.
 
 ## 5. Technical Decisions & Integrations
@@ -74,7 +74,7 @@ browse the level).
 | Component or Screen | API Integration | Description |
 | ------------------- | --------------- | ----------- |
 | Level track, Continue CTA | `GET /me/progress` (`tome-ms-language`, via `TomeLearningDashboardAPI.getMeProgress`) | Returns the user's current CEFR level, a status summary for all 6 levels, and the per-module status list for the current level. Drives the level track, the module-dot progress, and (via `deriveCurrentModule`) the Continue CTA's target module. |
-| Weekly stats | `GET /me/stats/dailyActivity?from=YYYYMMDD` (`tome-ms-language`, via `TomeLearningDashboardAPI.getWeeklySessionStats`) | Returns per-day activity counts for the **rolling 7-day window ending today** (F24). `from` is computed client-side as **today − 6 days** (YYYYMMDD). Response shape: `{ from, to, days: [{ date, practiceSessions, successfulModuleTests, successfulLevelTests }] }`, 7 entries oldest → today. The bar chart consumes `practiceSessions`; the other counts are available for future widgets. |
+| Weekly stats | `GET /me/stats/dailyActivity?from=YYYYMMDD` (`tome-ms-language`, via `TomeLearningDashboardAPI.getWeeklySessionStats`) | Returns per-day activity counts for the **rolling 7-day window ending today** (F24). `from` is computed client-side as **today − 6 days** (YYYYMMDD). Response shape: `{ from, to, days: [{ date, practiceSessions, successfulModuleTests, successfulLevelTests }] }`, 7 entries oldest → today. The stacked bar chart consumes all three counts (via `utils/weeklyBarStack.ts`'s `computeWeeklyBarStacks`); no unused fields remain. |
 
 ## 6. Success Criteria
 

--- a/utils/weeklyBarStack.ts
+++ b/utils/weeklyBarStack.ts
@@ -1,0 +1,50 @@
+import { DailyActivityDay } from '@/api/TomeLearningDashboardAPI';
+
+const MAX_BAR_HEIGHT = 84;
+const MIN_BAR_HEIGHT = 8;
+
+export interface WeeklyBarStack {
+    date: string;
+    total: number;
+    barHeight: number;
+    practiceHeight: number;
+    moduleTestHeight: number;
+    levelTestHeight: number;
+}
+
+/**
+ * Computes stacked bar-chart segment heights for the "This week" widget: each
+ * day's bar stacks practiceSessions (bottom), successfulModuleTests (middle)
+ * and successfulLevelTests (top), sized proportionally to its share of the
+ * day's total, with the overall bar height normalized against the highest
+ * daily total in the window (floored at 1 to avoid divide-by-zero when every
+ * day is empty).
+ *
+ * @param {DailyActivityDay[]} days - The rolling-window days to compute stacks for.
+ *
+ * @returns {WeeklyBarStack[]} One stack per input day, same order.
+ */
+export function computeWeeklyBarStacks(days: DailyActivityDay[]): WeeklyBarStack[] {
+
+    const totals = days.map((d) => d.practiceSessions + d.successfulModuleTests + d.successfulLevelTests);
+    const maxTotal = Math.max(...totals, 1);
+
+    return days.map((day, i) => {
+        const total = totals[i];
+
+        if (total === 0) {
+            return { date: day.date, total: 0, barHeight: 0, practiceHeight: 0, moduleTestHeight: 0, levelTestHeight: 0 };
+        }
+
+        const barHeight = Math.max((total / maxTotal) * MAX_BAR_HEIGHT, MIN_BAR_HEIGHT);
+
+        return {
+            date: day.date,
+            total,
+            barHeight,
+            practiceHeight: (day.practiceSessions / total) * barHeight,
+            moduleTestHeight: (day.successfulModuleTests / total) * barHeight,
+            levelTestHeight: (day.successfulLevelTests / total) * barHeight,
+        };
+    });
+}


### PR DESCRIPTION
## Summary
- The "This week" bar chart on the Language Learning home dashboard previously showed bar height based only on `practiceSessions`, discarding `successfulModuleTests` and `successfulLevelTests` already present in the `GET /me/stats/dailyActivity` payload.
- Each day's bar is now a stacked bar: practice sessions (bottom), successful module tests (middle), successful level tests (top), normalized against the busiest day in the 7-day window, using 3 shades of the existing bar color (no legend).
- Added a pure, unit-tested helper `utils/weeklyBarStack.ts` (`computeWeeklyBarStacks`) that computes the per-day segment heights, extracted so the math is testable independent of the React component.
- Updated `docs/features/01-home-dashboard.md` (§3, §4, §5) to describe the stacked-bar behavior.

## Test plan
- [x] `__tests__/weeklyBarStack.test.ts` — new unit tests for the stacking/height math (mixed day, test-only day, all-zero day, max/half/min-floor bar heights)
- [x] `npx jest` — full suite (78 tests) passes
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — production build succeeds
- [ ] Manual check in a browser: load the Language Learning home dashboard with a user that has a mix of practice sessions, module test passes, and level test passes across the week, and confirm the stacked bar renders correctly, today's bar is still emphasised, and empty days keep the dim empty-bar treatment

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)