### PR TITLE
Fix Sentence Reorder duplicate-word toggling

### DIFF
--- a/__tests__/sentenceReorderWords.test.ts
+++ b/__tests__/sentenceReorderWords.test.ts
@@ -1,0 +1,88 @@
+import { tagWords, toggleWordId, resolveBuiltWords } from '../utils/sentenceReorderWords';
+
+describe('tagWords', () => {
+
+    it('tags each word with its index as id', () => {
+        const result = tagWords(['Jeg', 'spiser', 'fisk']);
+
+        expect(result).toEqual([
+            { id: 0, text: 'Jeg' },
+            { id: 1, text: 'spiser' },
+            { id: 2, text: 'fisk' },
+        ]);
+    });
+
+    it('gives duplicate words distinct ids', () => {
+        const result = tagWords(['spiser', 'ikke', 'spiser']);
+
+        expect(result[0]).toEqual({ id: 0, text: 'spiser' });
+        expect(result[2]).toEqual({ id: 2, text: 'spiser' });
+    });
+
+    it('returns an empty array for an empty input', () => {
+        const result = tagWords([]);
+
+        expect(result).toEqual([]);
+    });
+
+});
+
+describe('toggleWordId', () => {
+
+    it('appends an id that is not yet built', () => {
+        const result = toggleWordId([0, 2], 1);
+
+        expect(result).toEqual([0, 2, 1]);
+    });
+
+    it('removes an id that is already built', () => {
+        const result = toggleWordId([0, 1, 2], 1);
+
+        expect(result).toEqual([0, 2]);
+    });
+
+    it('only removes the clicked instance of a duplicated word, not every occurrence sharing its text', () => {
+        // "spiser" appears at id 1 and id 4 — both are built, only id 1 is toggled off
+        const built = [1, 2, 4];
+
+        const result = toggleWordId(built, 1);
+
+        expect(result).toEqual([2, 4]);
+    });
+
+    it('does not mutate the input array', () => {
+        const built = [0, 1];
+
+        toggleWordId(built, 2);
+
+        expect(built).toEqual([0, 1]);
+    });
+
+});
+
+describe('resolveBuiltWords', () => {
+
+    it('maps built ids back to their word text in order', () => {
+        const words = ['Jeg', 'spiser', 'ikke', 'kød'];
+
+        const result = resolveBuiltWords(words, [1, 0, 2, 3]);
+
+        expect(result).toEqual(['spiser', 'Jeg', 'ikke', 'kød']);
+    });
+
+    it('reconstructs a sentence containing a duplicated word correctly', () => {
+        // "Jeg spiser ikke kød, men jeg spiser fisk" — "spiser" at index 1 and 6
+        const words = ['Jeg', 'spiser', 'ikke', 'kød,', 'men', 'jeg', 'spiser', 'fisk'];
+
+        const result = resolveBuiltWords(words, [0, 1, 2, 3, 4, 5, 6, 7]);
+
+        expect(result).toEqual(['Jeg', 'spiser', 'ikke', 'kød,', 'men', 'jeg', 'spiser', 'fisk']);
+    });
+
+    it('returns an empty array when no ids are built', () => {
+        const result = resolveBuiltWords(['a', 'b'], []);
+
+        expect(result).toEqual([]);
+    });
+
+});

--- a/app/language-learning/level-test/page.tsx
+++ b/app/language-learning/level-test/page.tsx
@@ -6,6 +6,7 @@ import { useHeader } from '@/context/HeaderContext';
 import { TomeLearningDashboardAPI, CefrLevel, MeProgressResponse } from '@/api/TomeLearningDashboardAPI';
 import { TomeLevelTestAPI, LevelTestEligibilityResponse, SubmitLevelTestResponse, LevelTestReviewItem, LevelTestAttempt } from '@/api/TomeLevelTestAPI';
 import { Exercise } from '@/api/TomePracticeSessionAPI';
+import { toggleWordId, resolveBuiltWords } from '@/utils/sentenceReorderWords';
 import { LevelTestReady, LEVEL_TEST_PASS_THRESHOLD } from './components/LevelTestReady';
 import { LevelTestPass } from './components/LevelTestPass';
 import { TestSubmit } from '../module/[moduleId]/test/components/TestSubmit';
@@ -60,7 +61,7 @@ export default function LevelTestPage() {
     const [submissionState, setSubmissionState] = useState<SubmissionState | null>(null);
     const [inputValue, setInputValue] = useState('');
     const [selectedOption, setSelectedOption] = useState<string | null>(null);
-    const [builtWords, setBuiltWords] = useState<string[]>([]);
+    const [builtWords, setBuiltWords] = useState<number[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     // Result / review
@@ -157,7 +158,7 @@ export default function LevelTestPage() {
     function handleCheck(overrideAnswer?: string) {
         if (!currentExercise) return;
         if (currentExercise.type === 'multiple_choice') handleSubmitAnswer(overrideAnswer ?? selectedOption ?? '');
-        else if (currentExercise.type === 'sentence_reorder') handleSubmitAnswer(builtWords.join(' '));
+        else if (currentExercise.type === 'sentence_reorder') handleSubmitAnswer(resolveBuiltWords(currentExercise.words ?? [], builtWords).join(' '));
         else if (currentExercise.type === 'error_correction') handleSubmitAnswer(inputValue);
     }
 
@@ -253,7 +254,7 @@ export default function LevelTestPage() {
                             <ExMultipleChoice exercise={currentExercise} submissionState={submissionState} selectedOption={selectedOption} onSelect={setSelectedOption} onCheck={handleCheck} isSubmitting={isSubmitting} />
                         )}
                         {currentExercise.type === 'sentence_reorder' && (
-                            <ExSentenceReorder exercise={currentExercise} submissionState={submissionState} builtWords={builtWords} onToggleWord={w => setBuiltWords(prev => prev.includes(w) ? prev.filter(x => x !== w) : [...prev, w])} onCheck={handleCheck} isSubmitting={isSubmitting} />
+                            <ExSentenceReorder exercise={currentExercise} submissionState={submissionState} builtWordIds={builtWords} onToggleWord={id => setBuiltWords(prev => toggleWordId(prev, id))} onCheck={handleCheck} isSubmitting={isSubmitting} />
                         )}
                         {currentExercise.type === 'fill_blank' && (
                             <ExFillBlank exercise={currentExercise} submissionState={submissionState} inputValue={inputValue} onInputChange={setInputValue} onSend={handleSend} isSubmitting={isSubmitting} />

--- a/app/language-learning/module/[moduleId]/practice/[practiceId]/page.tsx
+++ b/app/language-learning/module/[moduleId]/practice/[practiceId]/page.tsx
@@ -7,6 +7,7 @@ import { TomeLearningDashboardAPI } from '@/api/TomeLearningDashboardAPI';
 import { TomePracticeSessionAPI, Exercise } from '@/api/TomePracticeSessionAPI';
 import { reconstructSessionState } from '@/utils/reconstructSessionState';
 import { useAnswerVerification } from '@/utils/useAnswerVerification';
+import { toggleWordId, resolveBuiltWords } from '@/utils/sentenceReorderWords';
 import { SessionProgressBar } from '@/components/SessionProgressBar';
 import { ResultSheet } from '../components/ResultSheet';
 import { AIVerifyTray } from '../components/AIVerifyTray';
@@ -60,7 +61,7 @@ export default function PracticeSessionPage() {
     const [submissionState, setSubmissionState] = useState<SubmissionState | null>(null);
     const [inputValue, setInputValue] = useState('');
     const [selectedOption, setSelectedOption] = useState<string | null>(null);
-    const [builtWords, setBuiltWords] = useState<string[]>([]);
+    const [builtWords, setBuiltWords] = useState<number[]>([]);
 
     // ── Page meta state ───────────────────────────────────────────────────────
     const [loadState, setLoadState] = useState<LoadState>('loading');
@@ -138,7 +139,7 @@ export default function PracticeSessionPage() {
         if (!currentExercise) return;
         switch (currentExercise.type) {
             case 'multiple_choice':   handleSubmit(overrideAnswer ?? selectedOption ?? ''); break;
-            case 'sentence_reorder':  handleSubmit(builtWords.join(' ')); break;
+            case 'sentence_reorder':  handleSubmit(resolveBuiltWords(currentExercise.words ?? [], builtWords).join(' ')); break;
             case 'error_correction':  handleSubmit(inputValue); break;
         }
     }
@@ -257,10 +258,8 @@ export default function PracticeSessionPage() {
                             <ExSentenceReorder
                                 exercise={currentExercise}
                                 submissionState={submissionState}
-                                builtWords={builtWords}
-                                onToggleWord={w => setBuiltWords(prev =>
-                                    prev.includes(w) ? prev.filter(x => x !== w) : [...prev, w]
-                                )}
+                                builtWordIds={builtWords}
+                                onToggleWord={id => setBuiltWords(prev => toggleWordId(prev, id))}
                                 onCheck={handleCheck}
                                 isSubmitting={isSubmitting}
                             />

--- a/app/language-learning/module/[moduleId]/practice/components/ExSentenceReorder.tsx
+++ b/app/language-learning/module/[moduleId]/practice/components/ExSentenceReorder.tsx
@@ -1,6 +1,7 @@
 import { Exercise } from '@/api/TomePracticeSessionAPI';
 import { SubmissionState } from '../types';
 import { CheckFooter } from './CheckFooter';
+import { tagWords } from '@/utils/sentenceReorderWords';
 
 interface WordTileProps {
     word: string;
@@ -31,17 +32,18 @@ function WordTile({word, tone, onClick, disabled}: WordTileProps) {
 interface ExSentenceReorderProps {
     exercise: Exercise;
     submissionState: SubmissionState | null;
-    builtWords: string[];
-    onToggleWord: (word: string) => void;
+    builtWordIds: number[];
+    onToggleWord: (id: number) => void;
     onCheck: () => void;
     isSubmitting: boolean;
 }
 
-export function ExSentenceReorder({exercise, submissionState, builtWords, onToggleWord, onCheck, isSubmitting}: ExSentenceReorderProps) {
-    const allWords = exercise.words ?? [];
-    const bankWords = allWords.filter(w => !builtWords.includes(w));
+export function ExSentenceReorder({exercise, submissionState, builtWordIds, onToggleWord, onCheck, isSubmitting}: ExSentenceReorderProps) {
+    const allWords = tagWords(exercise.words ?? []);
+    const bankWords = allWords.filter(w => !builtWordIds.includes(w.id));
+    const placedWords = builtWordIds.map(id => allWords.find(w => w.id === id)!);
     const submitted = submissionState !== null;
-    const allPlaced = builtWords.length === allWords.length;
+    const allPlaced = builtWordIds.length === allWords.length;
 
     function tileTone(): 'correct' | 'wrong' {
         return submissionState?.isCorrect ? 'correct' : 'wrong';
@@ -61,15 +63,15 @@ export function ExSentenceReorder({exercise, submissionState, builtWords, onTogg
             <div className={`mt-6 min-h-14 border-b-2 pb-3 flex flex-wrap gap-2 items-center transition-colors ${
                 submitted && !submissionState?.isCorrect ? 'border-red-800' : 'border-cyan-400'
             }`}>
-                {builtWords.length === 0 && !submitted && (
+                {placedWords.length === 0 && !submitted && (
                     <span className="text-sm text-black/30">Tap words below to build the sentence</span>
                 )}
-                {builtWords.map((word, i) => (
+                {placedWords.map(word => (
                     <WordTile
-                        key={`placed-${i}`}
-                        word={word}
+                        key={`placed-${word.id}`}
+                        word={word.text}
                         tone={submitted ? tileTone() : 'placed'}
-                        onClick={() => !submitted && !isSubmitting && onToggleWord(word)}
+                        onClick={() => !submitted && !isSubmitting && onToggleWord(word.id)}
                         disabled={submitted || isSubmitting}
                     />
                 ))}
@@ -78,12 +80,12 @@ export function ExSentenceReorder({exercise, submissionState, builtWords, onTogg
             {/* Word bank */}
             {!submitted && (
                 <div className="mt-4 flex flex-wrap gap-2 justify-center">
-                    {bankWords.map((word, i) => (
+                    {bankWords.map(word => (
                         <WordTile
-                            key={`bank-${i}`}
-                            word={word}
+                            key={`bank-${word.id}`}
+                            word={word.text}
                             tone="bank"
-                            onClick={() => !isSubmitting && onToggleWord(word)}
+                            onClick={() => !isSubmitting && onToggleWord(word.id)}
                             disabled={isSubmitting}
                         />
                     ))}

--- a/app/language-learning/module/[moduleId]/test/page.tsx
+++ b/app/language-learning/module/[moduleId]/test/page.tsx
@@ -7,6 +7,7 @@ import { TomeLearningDashboardAPI } from '@/api/TomeLearningDashboardAPI';
 import { TomeModuleAPI, ModuleResponse } from '@/api/TomeModuleAPI';
 import { TomeModuleTestAPI, TestEligibilityResponse, SubmitTestResponse, TestReviewItem, TestAttempt } from '@/api/TomeModuleTestAPI';
 import { Exercise } from '@/api/TomePracticeSessionAPI';
+import { toggleWordId, resolveBuiltWords } from '@/utils/sentenceReorderWords';
 import { TestLocked } from './components/TestLocked';
 import { TestReady } from './components/TestReady';
 import { TestSubmit } from './components/TestSubmit';
@@ -66,7 +67,7 @@ export default function ModuleTestPage() {
     const [submissionState, setSubmissionState] = useState<SubmissionState | null>(null);
     const [inputValue, setInputValue] = useState('');
     const [selectedOption, setSelectedOption] = useState<string | null>(null);
-    const [builtWords, setBuiltWords] = useState<string[]>([]);
+    const [builtWords, setBuiltWords] = useState<number[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     // Result / review
@@ -165,7 +166,7 @@ export default function ModuleTestPage() {
     function handleCheck(overrideAnswer?: string) {
         if (!currentExercise) return;
         if (currentExercise.type === 'multiple_choice') handleSubmitAnswer(overrideAnswer ?? selectedOption ?? '');
-        else if (currentExercise.type === 'sentence_reorder') handleSubmitAnswer(builtWords.join(' '));
+        else if (currentExercise.type === 'sentence_reorder') handleSubmitAnswer(resolveBuiltWords(currentExercise.words ?? [], builtWords).join(' '));
         else if (currentExercise.type === 'error_correction') handleSubmitAnswer(inputValue);
     }
 
@@ -279,7 +280,7 @@ export default function ModuleTestPage() {
                             <ExMultipleChoice exercise={currentExercise} submissionState={submissionState} selectedOption={selectedOption} onSelect={setSelectedOption} onCheck={handleCheck} isSubmitting={isSubmitting} />
                         )}
                         {currentExercise.type === 'sentence_reorder' && (
-                            <ExSentenceReorder exercise={currentExercise} submissionState={submissionState} builtWords={builtWords} onToggleWord={w => setBuiltWords(prev => prev.includes(w) ? prev.filter(x => x !== w) : [...prev, w])} onCheck={handleCheck} isSubmitting={isSubmitting} />
+                            <ExSentenceReorder exercise={currentExercise} submissionState={submissionState} builtWordIds={builtWords} onToggleWord={id => setBuiltWords(prev => toggleWordId(prev, id))} onCheck={handleCheck} isSubmitting={isSubmitting} />
                         )}
                         {currentExercise.type === 'fill_blank' && (
                             <ExFillBlank exercise={currentExercise} submissionState={submissionState} inputValue={inputValue} onInputChange={setInputValue} onSend={handleSend} isSubmitting={isSubmitting} />

--- a/utils/sentenceReorderWords.ts
+++ b/utils/sentenceReorderWords.ts
@@ -1,0 +1,51 @@
+/** A single word tile carrying a stable per-instance identity, so duplicate words in a sentence can be told apart. */
+export interface WordTile {
+    id: number;    // The word's index in the original words array — stable across the exercise's lifetime
+    text: string;  // The word's text
+}
+
+/**
+ * Tags each word in a sentence with a per-instance id (its original index).
+ *
+ * This gives duplicate words (e.g. "spiser" appearing twice in a sentence) distinct
+ * identities, so selection/removal can operate on id rather than on string value.
+ *
+ * @param words - The exercise's words, in their original order
+ *
+ * @returns A `WordTile[]` where each tile's `id` is its index in `words`
+ */
+export function tagWords(words: string[]): WordTile[] {
+
+    return words.map((text, id) => ({ id, text }));
+}
+
+/**
+ * Toggles a single word instance in the built (placed) list, by id.
+ *
+ * Because ids are per-instance, toggling one occurrence of a duplicated word
+ * never affects any other occurrence sharing the same text.
+ *
+ * @param builtIds - The ids currently placed in the answer, in order
+ * @param id - The id of the word instance being toggled
+ *
+ * @returns A new array with `id` removed if it was present, or appended otherwise
+ */
+export function toggleWordId(builtIds: number[], id: number): number[] {
+
+    if (builtIds.includes(id)) return builtIds.filter(builtId => builtId !== id);
+
+    return [...builtIds, id];
+}
+
+/**
+ * Resolves a list of built ids back into the words they represent, in order.
+ *
+ * @param words - The exercise's words, in their original order (same array `tagWords` was given)
+ * @param builtIds - The ids placed in the answer, in the order they were placed
+ *
+ * @returns The words corresponding to `builtIds`, in order
+ */
+export function resolveBuiltWords(words: string[], builtIds: number[]): string[] {
+
+    return builtIds.map(id => words[id]);
+}


### PR DESCRIPTION
## Summary
- Word selection/removal in the Sentence Reorder exercise matched words by string value, so a sentence with a repeated word (e.g. "spiser" in "Jeg spiser ikke kød, men jeg spiser fisk") toggled both occurrences at once, making such sentences impossible to complete.
- Added `utils/sentenceReorderWords.ts` giving each word a stable per-instance id (`tagWords`, `toggleWordId`, `resolveBuiltWords`), and wired it through `ExSentenceReorder.tsx` and its 3 call sites (practice session, module test, level test) so tiles are placed/removed by id instead of by text.

## Test plan
- [x] `npx jest` — 127/127 passing, including new `__tests__/sentenceReorderWords.test.ts` covering the duplicate-word scenario
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — builds successfully
- [ ] Manual smoke test of a Sentence Reorder exercise with a repeated word in practice, module test, and level test screens

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)