### PR TITLE
Content generation: production-gate-aware translation_active rules

### DIFF
--- a/.claude/skills/generate-module-content/rules-for-generation.md
+++ b/.claude/skills/generate-module-content/rules-for-generation.md
@@ -42,18 +42,26 @@ The progression reflects a deliberate pedagogical shift: at A1 recognition is ap
 ## Cross-cutting rules (all exercise types)
 
 - Always set `type` to the correct string value: `multiple_choice`, `fill_blank`, `sentence_reorder`, `conjugation_drill`, `error_correction`, or `translation_active`.
-- **Exactly one of `vocabularyItemId` or `grammarConceptId` must be set — never both, never neither.** The assignment is determined by exercise type, not by content:
+- **Exactly one of `vocabularyItemId` or `grammarConceptId` must be set — never both, never neither.** For most types the assignment is fixed by exercise type; `translation_active` is the one exception, where it depends on content:
 
   | Type | Links to |
   |---|---|
   | `multiple_choice` | `vocabularyItemId` |
   | `fill_blank` | `vocabularyItemId` |
   | `conjugation_drill` | `vocabularyItemId` (the verb being drilled; its forms are part of knowing the word) |
-  | `translation_active` | `vocabularyItemId` |
+  | `translation_active` | `vocabularyItemId` **or** `grammarConceptId` — whichever the exercise's single focus is testing (see below) |
   | `sentence_reorder` | `grammarConceptId` |
   | `error_correction` | `grammarConceptId` |
 
-- **Coverage is a hard MUST.** The bank must include **at least one** exercise for **every vocabulary item** in the module — ideally **two** — and **at least one** for **every grammar concept**. Vocabulary items are covered by vocabulary exercise types; grammar concepts are covered by grammar exercise types. This is enforced by `validate_coverage.py` (Phase 4, Step 1): generation is not done until it exits 0. Aim for two exercises per vocabulary item as you generate, so coverage passes on the first run.
+  For `translation_active`, decide the link by what the exercise is actually testing: if the English prompt's only real challenge is recalling/producing a specific word, link `vocabularyItemId`; if the only real challenge is producing a specific grammatical structure (word order, inversion, negation placement, etc.), link `grammarConceptId` instead. See the "Translation (Active)" section below for authoring guidance on the grammar-linked case.
+
+- **Coverage is a hard MUST, and it now has two independent targets:**
+  - **Baseline (scaffolding) coverage** — every vocabulary item and every grammar concept must have **at least one** exercise of any type. This is the existing floor and stays as-is; aim for two exercises per item so this passes comfortably.
+  - **Production coverage (new, gates practice completion)** — every vocabulary item **and** every grammar concept must additionally have **at least two `translation_active` exercises** each. This is the number that actually matters: the app's practice-completion gate counts correct answers on `translation_active` exercises specifically, so a vocab item or grammar concept with only `multiple_choice`/`fill_blank`/`sentence_reorder`/etc. coverage will never let a user complete practice for it, no matter how many non-`translation_active` exercises exist. Two *distinct* exercises are required (not one exercise reused) so a user's two spaced production reps aren't the same question twice.
+
+  Both checks are enforced by `validate_coverage.py` (Phase 4, Step 1): generation is not done until it exits 0.
+
+  > **Bank-size note:** the production-coverage requirement is a much bigger ask than it looks. A typical A1 module (e.g. ~47 vocab items + ~3 grammar concepts) now needs on the order of **100 `translation_active` exercises** just to satisfy this, versus banks generated under the old rules that had as few as 17. In practice this means the overall exercise bank must grow substantially (roughly 2–3x current sizes) — you cannot hit this by only adding more `translation_active` exercises in isolation; the other exercise types must scale up proportionally too, or they'll fall below their own distribution floors (see the composition table above). `validate_distribution.py` needs no logic change for this — `translation_active` already has no ceiling — but expect noticeably larger banks going forward.
 - `timesShown` is always `0` at generation time.
 - Sentences must reflect the module's theme and CEFR register — a B2 business module should not produce A1-sounding sentences.
 - Use vocabulary the learner has already seen earlier in the session (the Multiple Choice → Translation ordering scaffolds this).
@@ -229,9 +237,13 @@ The progression reflects a deliberate pedagogical shift: at A1 recognition is ap
 - Store `alternativeAnswers` in natural form (not pre-normalized). The matching engine normalizes before comparing.
 - The English prompt must be unambiguous. If the sentence has two possible readings, constrain it with a context note or rewrite it.
 - At A1–A2, use single-clause sentences. At B1+, the prompt may include two clauses; at C1+, it may include a dependent clause or idiomatic structure.
-- If a vocabulary item carries a `context` note in the data model, scope the prompt and alternatives to that sense (e.g., *stor — physical size*).
+- This type links to **either** `vocabularyItemId` or `grammarConceptId` (see Cross-cutting rules above) — decide which before writing the prompt, since that decision shapes what the sentence must force:
+  - **Vocabulary-focused**: if a vocabulary item carries a `context` note in the data model, scope the prompt and alternatives to that sense (e.g., *stor — physical size*). Any grammar the sentence happens to involve is incidental — pick simple, already-mastered structures so the only real challenge is recalling/producing the target word.
+  - **Grammar-focused**: the English prompt must force the specific structure being tested (e.g. inversion after a fronted adverbial, subordinate-clause word order, negation placement) as an unavoidable, non-incidental part of a correct answer — the same standard `sentence_reorder`/`error_correction` already hold grammar exercises to. A learner must not be able to produce a correct Danish sentence while sidestepping the tested structure (e.g. by choosing a different word order that avoids it). Vocabulary used in the sentence should already be familiar/simple, so the difficulty is isolated to the grammar point, not split across two unknowns.
 
 **JSON output spec**
+
+Vocabulary-focused example:
 ```json
 {
   "type": "translation_active",
@@ -242,6 +254,21 @@ The progression reflects a deliberate pedagogical shift: at A1 recognition is ap
   "alternativeAnswers": ["valid paraphrase 1", "valid paraphrase 2"],
   "vocabularyItemId": "<id>",
   "grammarConceptId": null,
+  "timesShown": 0
+}
+```
+
+Grammar-focused example (`vocabularyItemId`/`grammarConceptId` swap — everything else about the shape is identical):
+```json
+{
+  "type": "translation_active",
+  "prompt": "English sentence engineered so a correct answer requires the tested structure",
+  "promptTranslation": null,
+  "answer": "Canonical Danish translation exhibiting the tested structure",
+  "distractors": [],
+  "alternativeAnswers": ["valid paraphrase 1 (still exhibiting the structure)"],
+  "vocabularyItemId": null,
+  "grammarConceptId": "<id>",
   "timesShown": 0
 }
 ```

--- a/.claude/skills/generate-module-content/validate_coverage.py
+++ b/.claude/skills/generate-module-content/validate_coverage.py
@@ -2,32 +2,50 @@
 """
 Validates that the exercise bank covers every vocabulary item and grammar concept.
 
-This is the hard coverage gate for module generation. The MUST requirement is:
-**every vocabulary item has at least one exercise** (idea.md §3.1.3). The target is
-**two exercises per vocabulary item**. Grammar concepts must also have at least one
-exercise each.
+This enforces two independent coverage gates for module generation:
+
+1. Baseline (scaffolding) coverage — the MUST requirement is: **every vocabulary
+   item and every grammar concept has at least one exercise of any type**
+   (idea.md §3.1.3). The target is two exercises per vocabulary item. Below-target
+   vocab items only WARN by default (promote to FAIL with --strict).
+
+2. Production coverage — the practice-completion gate (see the spaced-production
+   practice gate proposal) counts only correct answers on `translation_active`
+   exercises. A vocab item or grammar concept can pass check #1 above yet still
+   never let a user complete practice, if it has zero/insufficient `translation_active`
+   coverage. This is why production coverage is checked independently: **every
+   vocabulary item and every grammar concept must have at least --production-target
+   `translation_active` exercises** (default: 2). This check is always a hard FAIL
+   — it is not gated behind --strict.
 
 Usage:
-    python3 validate_coverage.py <module_id> <exercises_file> [--strict] [--target N]
+    python3 validate_coverage.py <module_id> <exercises_file> [--strict] [--target N] [--production-target N]
 
 Arguments:
     module_id       Module code, e.g. A1-01
     exercises_file  Path to the module's *-exercises.json file
 
 Options:
-    --strict        Promote the per-vocab-item target from a WARN to a hard FAIL,
-                    i.e. require every vocab item to have >= target exercises.
-    --target N      Desired exercises per vocabulary item (default: 2).
+    --strict              Promote the per-vocab-item any-type target from a WARN to a
+                          hard FAIL, i.e. require every vocab item to have >= target
+                          exercises of any type. Does not affect the production-coverage
+                          check, which is always a hard FAIL regardless of this flag.
+    --target N            Desired exercises of any type per vocabulary item (default: 2).
+    --production-target N Desired `translation_active` exercises per vocabulary item AND
+                          per grammar concept (default: 2). Always a hard FAIL if unmet.
 
 The vocabulary file is auto-detected as the sibling *-vocabulary.json and the grammar
 file as the sibling *-grammar.json. Both are required — coverage cannot be checked
 without the full list of items that must be covered.
 
 Exit codes:
-    0   Every vocab item has >= 1 exercise (>= target in --strict) AND every grammar
-        concept has >= 1 exercise. Below-target vocab items only WARN (unless --strict).
+    0   Every vocab item and grammar concept has >= 1 exercise of any type (>= target in
+        --strict), AND every vocab item and grammar concept has >= production-target
+        `translation_active` exercises. Below-target (any-type) vocab items only WARN
+        unless --strict.
     1   One or more vocab items or grammar concepts are uncovered (hard MUST violated),
-        a referenced id does not exist, or --strict and a vocab item is below target.
+        a referenced id does not exist, --strict and a vocab item is below the any-type
+        target, or any vocab item/grammar concept is below the production-coverage target.
 """
 
 import argparse
@@ -61,11 +79,15 @@ def main() -> None:
                         help="require every vocab item to reach the target, not just 1")
     parser.add_argument("--target", type=int, default=2,
                         help="desired exercises per vocabulary item (default: 2)")
+    parser.add_argument("--production-target", type=int, default=2,
+                        help="desired translation_active exercises per vocabulary item "
+                             "and per grammar concept (default: 2); always a hard FAIL if unmet")
     args = parser.parse_args()
 
     module_id = args.module_id
     exercises_file = args.exercises_file
     target = args.target
+    production_target = args.production_target
 
     vocab_file = exercises_file.replace("-exercises.json", "-vocabulary.json")
     grammar_file = exercises_file.replace("-exercises.json", "-grammar.json")
@@ -80,18 +102,27 @@ def main() -> None:
     # Count how many exercises reference each vocab item / grammar concept.
     vocab_counts: Counter[str] = Counter()
     grammar_counts: Counter[str] = Counter()
+    # Same, but restricted to translation_active exercises only — this is what the
+    # practice-completion production gate actually consumes.
+    vocab_production_counts: Counter[str] = Counter()
+    grammar_production_counts: Counter[str] = Counter()
     dangling_vocab: set[str] = set()
     dangling_grammar: set[str] = set()
 
     for ex in exercises:
         vid = ex.get("vocabularyItemId")
         gid = ex.get("grammarConceptId")
+        is_production = ex.get("type") == "translation_active"
         if vid:
             vocab_counts[vid] += 1
+            if is_production:
+                vocab_production_counts[vid] += 1
             if vid not in vocab_ids:
                 dangling_vocab.add(vid)
         if gid:
             grammar_counts[gid] += 1
+            if is_production:
+                grammar_production_counts[gid] += 1
             if gid not in grammar_ids:
                 dangling_grammar.add(gid)
 
@@ -103,11 +134,22 @@ def main() -> None:
     )
     uncovered_grammar = sorted(gid for gid in grammar_ids if grammar_counts.get(gid, 0) == 0)
 
+    # Production-coverage buckets (translation_active only, always a hard gate).
+    below_production_vocab = sorted(
+        (vid for vid in vocab_ids if vocab_production_counts.get(vid, 0) < production_target),
+        key=lambda v: (vocab_production_counts[v], v),
+    )
+    below_production_grammar = sorted(
+        (gid for gid in grammar_ids if grammar_production_counts.get(gid, 0) < production_target),
+        key=lambda g: (grammar_production_counts[g], g),
+    )
+
     # ── Header ──────────────────────────────────────────────────────────────
     print(f"\nExercise Bank Coverage — {module_id}")
     print(f"Total exercises: {len(exercises)}")
     print(f"Vocabulary items: {len(vocab_ids)}  |  Grammar concepts: {len(grammar_ids)}")
     print(f"Target exercises per vocab item: {target}{'  (strict: enforced as hard FAIL)' if args.strict else ''}")
+    print(f"Production target (translation_active) per vocab item and grammar concept: {production_target} (always enforced as hard FAIL)")
     print()
 
     covered_at_target = sum(1 for vid in vocab_ids if vocab_counts.get(vid, 0) >= target)
@@ -115,6 +157,10 @@ def main() -> None:
     print(f"Vocab items with >= 1 exercise:        {covered_min}/{len(vocab_ids)}")
     print(f"Vocab items with >= {target} exercises (target): {covered_at_target}/{len(vocab_ids)}")
     print(f"Grammar concepts with >= 1 exercise:   {len(grammar_ids) - len(uncovered_grammar)}/{len(grammar_ids)}")
+    covered_production_vocab = len(vocab_ids) - len(below_production_vocab)
+    covered_production_grammar = len(grammar_ids) - len(below_production_grammar)
+    print(f"Vocab items with >= {production_target} translation_active exercises:    {covered_production_vocab}/{len(vocab_ids)}")
+    print(f"Grammar concepts with >= {production_target} translation_active exercises: {covered_production_grammar}/{len(grammar_ids)}")
     print()
 
     has_fail = False
@@ -155,6 +201,27 @@ def main() -> None:
             print(f"    - {vid} ({vocab_counts[vid]} exercise)")
         print()
 
+    # ── Production Coverage (translation_active) ─────────────────────────────
+    # Independent of the any-type checks above. Always a hard FAIL: the
+    # practice-completion gate counts only translation_active reps, so a vocab
+    # item or grammar concept below this target can never satisfy it, no
+    # matter how well it scores on the any-type checks.
+    if below_production_vocab or below_production_grammar:
+        has_fail = True
+        print(f"✗ FAIL — Production Coverage (translation_active) — target: {production_target} per item:")
+        if below_production_vocab:
+            print(f"  {len(below_production_vocab)} vocabulary item(s) below the translation_active target:")
+            for vid in below_production_vocab:
+                print(f"    - {vid} ({vocab_production_counts.get(vid, 0)} translation_active exercise(s))")
+        if below_production_grammar:
+            print(f"  {len(below_production_grammar)} grammar concept(s) below the translation_active target:")
+            for gid in below_production_grammar:
+                print(f"    - {gid} ({grammar_production_counts.get(gid, 0)} translation_active exercise(s))")
+        print()
+    else:
+        print(f"✓ Production Coverage (translation_active) — every vocab item and grammar concept has >= {production_target}.")
+        print()
+
     # ── Summary ──────────────────────────────────────────────────────────────
     if has_fail:
         print("Result: FAIL — coverage requirement not met.")
@@ -167,6 +234,10 @@ def main() -> None:
             print("  ✗ Fix or remove exercises that reference non-existent ids.")
         if args.strict and below_target_vocab:
             print(f"  ✗ Bring every below-target vocab item up to {target} exercises.")
+        if below_production_vocab:
+            print(f"  ✗ Add translation_active exercises for each of the {len(below_production_vocab)} vocab item(s) below the production target of {production_target}.")
+        if below_production_grammar:
+            print(f"  ✗ Add translation_active exercises for each of the {len(below_production_grammar)} grammar concept(s) below the production target of {production_target}.")
         print("\nRe-run this script after editing the exercises file. Repeat until exit 0.")
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

Scoped-down, in-repo portion of #319 ("Practice completion gate: require spaced production-type mastery, not just exposure"). Investigation confirmed `tome` is a frontend-only repo — the actual gate/mastery/session-generation logic lives server-side in `tome-ms-language`, so only the content-generation-skill changes described in §3.5 of the issue are implementable here. The rest of #319's scope has been filed as nicolasances/tome-ms-language#90.

- **`rules-for-generation.md`**: loosens the `translation_active` type→id binding so it can link to either `vocabularyItemId` or `grammarConceptId` (previously vocab-only), adds authoring guidance for the grammar-linked case, and adds a new hard coverage requirement (≥2 `translation_active` exercises per vocab item AND per grammar concept, alongside the existing ≥1-of-any-type baseline) plus a note on the resulting bank-size growth.
- **`validate_coverage.py`**: adds an independent, always-hard "Production Coverage" check enforcing that ≥2-per-item `translation_active` requirement (configurable via `--production-target`, default 2), for both vocab items and grammar concepts (grammar previously had no per-target check at all). The existing any-type check/flags are unchanged.

## Verification

- Hand-built pass/fail fixtures confirm the new check fails when an item has insufficient `translation_active` coverage and passes when the target is met.
- Regression-checked against real A1-01 module data: the any-type coverage section's output is unchanged; the new production-coverage check correctly fails (A1-01 has 17 `translation_active` exercises total vs. ~100 needed under the new per-item ×2 requirement).
- `npm run lint`, `npm test` (127 passed), and `npm run build` all pass — expected, since this change touches only `.claude/skills/` content, no application code.

Closes #319 (content-generation-skill portion; remaining backend scope tracked in nicolasances/tome-ms-language#90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)