### PR TITLE
Redirect app root (/) to /language-learning

### DIFF
--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -26,7 +26,6 @@ export default function Menu() {
                 <MenuItem onClick={() => router.push('/settings')} icon="/images/settings.svg" iconColor="bg-cyan-700" label="Settings" />
                 <div className="pt-4"></div>
                 <MenuItem onClick={() => router.push('/new-topic')} icon="/images/plus.svg" iconColor="bg-cyan-700" label="New Topic" />
-                <MenuItem onClick={() => router.push('/language-learning')} icon="/images/language.svg" iconColor="bg-cyan-700" label="Language Learning" />
             </div>
         </div>
     );

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/language-learning",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Add a permanent redirect (`next.config.ts` `redirects()`) sending `/` to `/language-learning`, so opening the app lands on the Home dashboard instead of the legacy topics/BrainView page.
- Remove the now-redundant "Language Learning" entry from the mobile menu (`app/menu/page.tsx`) — "Home" already routes to `/`, which now redirects to the same destination.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — all 145 tests pass
- [x] `npm run lint` — no new warnings/errors introduced
- [x] Manually verified `curl -I http://localhost:3000/` returns `308` redirect to `/language-learning`
- [x] Confirmed mobile menu no longer shows duplicate "Language Learning" entry

Fixes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)